### PR TITLE
Adds function to confirm a marketplace subscription

### DIFF
--- a/dev-portal/src/services/api-catalog.js
+++ b/dev-portal/src/services/api-catalog.js
@@ -70,6 +70,16 @@ export function addSubscription(usagePlanId) {
     })
 }
 
+export function confirmMarketplaceSubscription(usagePlanId, token) {
+    if (!usagePlanId) {
+      return
+    }
+
+    return getApiGatewayClient().then(apiGatewayClient => {
+        return apiGatewayClient.put('/marketplace-subscriptions/' + usagePlanId, {}, {"token" : token})
+    })
+}
+
 export function unsubscribe(usagePlanId) {
     return getApiGatewayClient().then(apiGatewayClient => {
         return apiGatewayClient.delete(`/subscriptions/${usagePlanId}`, {}, {}).then(function(result) {


### PR DESCRIPTION
We need a way to PUT /apig//marketplace-subscriptions/ to tell the dev lambdas to check the user's marketplace id and match them up to both our cognito id and subscribe them to the plan they purchased.