### PR TITLE
Explicitly package up lambdas/_common module before installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "delete-app-bucket": "aws s3 rb s3://$npm_package_config_siteS3Bucket --region $npm_package_config_primaryAwsRegion --force",
     "upload-site": "cd ./dev-portal && npm run build && aws s3 sync ./build s3://$npm_package_config_siteS3Bucket --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers --region $npm_package_config_primaryAwsRegion && cd ..",
     "delete-stack": "aws cloudformation delete-stack --stack-name $npm_package_config_cloudFormationStackName --region $npm_package_config_primaryAwsRegion",
-    "lambdas-npm-install": "cd lambdas/backend && npm uninstall common-lambda-assets --no-save && npm install && cd ../listener && npm uninstall common-lambda-assets --no-save && npm install && cd ..",
+    "lambdas-npm-install": "cd lambdas/backend && npm uninstall common-lambda-assets --no-save && npm pack ../_common && npm install common-lambda-assets-1.0.0.tgz && npm install && cd ../listener && npm uninstall common-lambda-assets --no-save && npm pack ../_common && npm install common-lambda-assets-1.0.0.tgz && npm install && cd ..",
     "subscribe-listener": "aws sns subscribe --topic-arn $npm_package_config_marketplaceSubscriptionTopic --protocol lambda --notification-endpoint arn:aws:lambda:$npm_package_config_primaryAwsRegion:$npm_package_config_accountId:function:$npm_package_config_listenerLambdaFunctionName --region us-east-1",
     "setup": "npm install && npm run pre-config && npm run create-artifacts-bucket && npm run lambdas-npm-install && npm run package-deploy && npm run post-setup",
     "post-setup": "npm run post-config && cd dev-portal && npm install && npm run upload-site && npm home",
@@ -47,7 +47,7 @@
     "win-delete-app-bucket": "aws s3 rb s3://%npm_package_config_siteS3Bucket% --region %npm_package_config_primaryAwsRegion% --force",
     "win-upload-site": "cd ./dev-portal && npm run build && aws s3 sync ./build s3://%npm_package_config_siteS3Bucket% --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers --region %npm_package_config_primaryAwsRegion% && cd ..",
     "win-delete-stack": "aws cloudformation delete-stack --stack-name %npm_package_config_cloudFormationStackName% --region %npm_package_config_primaryAwsRegion%",
-    "win-lambdas-npm-install": "cd lambdas/backend && npm uninstall common-lambda-assets --no-save && npm install && cd ../listener && npm uninstall common-lambda-assets --no-save && npm install && cd ..",
+    "win-lambdas-npm-install": "cd lambdas/backend && npm uninstall common-lambda-assets --no-save && npm pack ../_common && npm install common-lambda-assets-1.0.0.tgz && npm install && cd ../listener && npm uninstall common-lambda-assets --no-save && npm pack ../_common && npm install common-lambda-assets-1.0.0.tgz && npm install && cd ..",
     "win-subscribe-listener": "aws sns subscribe --topic-arn %npm_package_config_marketplaceSubscriptionTopic% --protocol lambda --notification-endpoint arn:aws:lambda:%npm_package_config_primaryAwsRegion%:%npm_package_config_accountId%:function:%npm_package_config_listenerLambdaFunctionName% --region us-east-1",
     "win-setup": "npm install && npm run win-pre-config && npm run win-create-artifacts-bucket && npm run win-lambdas-npm-install && npm run win-package-deploy && npm run win-post-setup",
     "win-post-setup": "npm run win-post-config && cd dev-portal && npm install && npm run win-upload-site && npm home"


### PR DESCRIPTION
Installing local dependencies either copies the module to node_modules/ or creates a symlink within node_modules/ depending on the NPM version. Symlinks won't work because they don't get sent up to S3 and a module is lost in the process. This change explicitly packages up the lambdas/_common module as a Tarball (using npm pack) and then is installed into node_modules/ ensuring that the full module directory is available