### PR TITLE
Update README and static-asset-uploader function settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sam package --template-file ./cloudformation/template.yaml --output-template-fil
 Then, replace "custom-prefix" in the command below with some prefix that is globally unique, like your org name or username and run:
 
 ```bash
-sam deploy --template-file ./packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts"
+sam deploy --template-file ./cloudformation/packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts"
 ```
 
 The command will exit when the stack creation is successful. If you'd like to watch it create in real-time, you can log into the cloudformation console.

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -691,10 +691,10 @@ Resources:
     Properties:
       CodeUri: ../lambdas/static-asset-uploader
       Handler: index.handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt DevPortalLambdaExecutionRole.Arn
       Runtime: nodejs8.10
-      Timeout: 20
+      Timeout: 300
       Environment:
         Variables:
           StaticBucketName: !Ref ArtifactsS3BucketName

--- a/lambdas/static-asset-uploader/index.js
+++ b/lambdas/static-asset-uploader/index.js
@@ -189,7 +189,7 @@ exports.handler = (event, context) => {
 
                     console.log(`readPromises length: ${readPromises.length}`)
 
-                    Promise.all(readPromises)
+                    return Promise.all(readPromises)
                         .then((readResults) => {
                             console.log('All read promises resolved.')
                             console.log(`uploadPromises length: ${uploadPromises.length}`)


### PR DESCRIPTION
While testing SAM deployment for windows, I realized that some change
(presumably library upgrades?) caused the static-asset-uploader to
alternately time out or crash because of memory pressure. This change
increases the lambda function timeout (20->300 seconds) and memory usage
(128->512 MB).

Also updated inaccurate instruction in README.