### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Trial-In-Error @etsung-aws @MynockSpit @bejos @nitishdayal

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @Trial-In-Error @etsung-aws @MynockSpit @bejos @nitishdayal
+README.md @a-tan


### PR DESCRIPTION
This tells github who "owns" code; they'll be automatically included in
CRs for that code. For right now, I've set the console team as owners
for everything ("*").

Docs on CODEOWNERS: https://help.github.com/articles/about-codeowners/