### PR TITLE
Add whole team to CODEOWNERS for README

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @Trial-In-Error @etsung-aws @MynockSpit @bejos @nitishdayal
-README.md @a-tan
+README.md @a-tan @Trial-In-Error @etsung-aws @MynockSpit @bejos @nitishdayal


### PR DESCRIPTION
Previously, @alantan's approval was required for any commit that touched
the README. Since we edit the README semi-frequently, we'd rather let
team members' approve PRs. @alantan is still included as a CODEOWNER for
the README so he'll receive email notifications & can provide input.