### PR TITLE
Fixes for catalog updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can override any of the parameters in the template using the `--parameter-ov
 
 ### Populate the Swagger catalog
 
-The developer portal only exposes a subset of your API Gateway managed APIs & stages. As of now, there's no support for APIs not managed by API Gateway. To expose an API to customers, associate that API & stage to a usage plan. Then, export the API's Swagger (must export as JSON, with API GW extensions) from the stage, and upload it to the `ArtifactsS3Bucket` (actual name provided as a parameter override on the CLI when deploying) in the `catalog` folder.
+The developer portal only exposes a subset of your API Gateway managed APIs & stages. As of now, there's no support for APIs not managed by API Gateway. To expose an API to customers, associate that API & stage to a usage plan. Then, export the API's Swagger (must export as JSON, with API GW extensions) from the stage, rename it in the format `apiId:stageName.json` and upload it to the `ArtifactsS3Bucket` (actual name provided as a parameter override on the CLI when deploying) in the `catalog` folder. An example might be named `d89n46zud1:production.json`.
 
 Uploading to the `catalog` folder will cause a `catalog.json` file to be generated automatically. This file should contain a mapping of usage plans to api-stage with the Swagger for that api-stage inline. If the `catalog.json` file looks correct, your developer portal should be ready to use!
 


### PR DESCRIPTION
There are several changes in this commit:

First, YAML files should be supported again in the catalog.

Second, usage plan throttle and quota information is exposed to the
front-end in the catalog. Closes #87.

Third, users can name their file API:STAGE.json or API:STAGE.yaml,
and their apiId and stageName will be extracted from the filename. An
example might be the file 'catalog/a1e3cf8aqu:production.json'. If the
file is not named in this format, we fall back to trying to extract the
apiId and stageName from the swagger's host and basePath fields. This
will fail if the api has a custom domain associated with it.