### PR TITLE
don't return bad catalog data if no catalog.json

### DIFF
--- a/lambdas/backend/catalog/index.js
+++ b/lambdas/backend/catalog/index.js
@@ -22,8 +22,16 @@ const usagePlans = function() {
       return usagePlanCatalog
     })
     .catch((error) => {
+      // don't break if there's no catalog file
+      if (error.code === "NoSuchKey") {
+        console.log('error: No catalog.json file found. Please upload an api definition to `catalog/`.')
+
+        return []
+      }
+      
       console.log(`error: ${error}`)
-      return Promise.reject(error)
+      
+      throw error
     })
 }
 

--- a/lambdas/backend/catalog/index.js
+++ b/lambdas/backend/catalog/index.js
@@ -24,12 +24,12 @@ const usagePlans = function() {
     .catch((error) => {
       // don't break if there's no catalog file
       if (error.code === "NoSuchKey") {
-        console.log('error: No catalog.json file found. Please upload an api definition to `catalog/`.')
+        console.error('error: No catalog.json file found. Please upload an api definition to `catalog/`.')
 
         return []
       }
       
-      console.log(`error: ${error}`)
+      console.error(`error: ${error}`)
       
       throw error
     })

--- a/lambdas/backend/express-server.js
+++ b/lambdas/backend/express-server.js
@@ -65,9 +65,9 @@ app.post('/signin', (req, res) => {
 
 // the API catalog could be statically defined (catalog/index.js), or generated from API Gateway Usage Plans (See getUsagePlans())
 app.get('/catalog', (req, res) => {
-    catalog().then((catalog) => {
-        res.status(200).json(catalog)
-    })
+    catalog()
+        .then(catalog => res.status(200).json(catalog))
+        .catch(error => res.status(error.statusCode).json(error))
 })
 
 app.get('/apikey', (req, res) => {


### PR DESCRIPTION
Send a specific cloudwatch log and return usable data if the catalog.json file doesn't exit.