### PR TITLE
Add custom domain name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ When logged into the developer portal with an account that has a provisioned api
 
 ## Before going to production
 
-You should [configure your domain name to point to your S3 website](http://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html) URL and enable SSL before officially launching your developer portal.
+You should [request and verify an ACM managed certificate for your custom domain name.](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html) Then, redeploy the CFN stack with the domain name as a parameter override:
 
-Additional Resources:
+```bash
+sam deploy --template-file ./cloudformation/packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts" CustomDomainName="my.acm.managed.domain.name.com"
+```
 
- - [Getting Started with Amazon CloudFront and AWS Certificate Manager](http://docs.aws.amazon.com/acm/latest/userguide/gs-cf.html)
+This will create a cloudfront distribution in front of the S3 bucket serving the site, set up a Route53 hosted zone with records aliased to that distribution, and require HTTPS to communicate with the developer portal S3 bucket.
 
- - [New – AWS Certificate Manager – Deploy SSL/TLS-Based Apps on AWS](https://aws.amazon.com/blogs/aws/new-aws-certificate-manager-deploy-ssltls-based-apps-on-aws/)
+After the deployment finishes, go to the Route53 console, find the nameservers for the hosted zone created by the deployment, and add those as the nameservers for your domain name through your registrar. The specifics of this process will vary by registrar.
 
 ## Components
 

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -39,6 +39,14 @@ Parameters:
     Description: The region to deploy to.
     Default: "us-east-1"
 
+  CustomDomainName:
+    Type: String
+    Description: Optionally provide a custom domain name associated with an ACM cert to create a developer portal at that domain name (provide with the format foo.bar.net). Leave blank to create a developer portal without a custom domain name. Standing up a developer portal stack with a custom domain name will take significantly longer than without.
+    Default: ''
+
+Conditions:
+  UseCustomDomainName: !Not [ !Equals [!Ref CustomDomainName, ''] ]
+
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api
@@ -823,6 +831,60 @@ Resources:
       UserPoolClientId: !Ref CognitoUserPoolClient
       MarketplaceSuffix: !Ref MarketplaceSubscriptionTopicProductCode
       RebuildToken: !Ref StaticAssetRebuildToken
+
+  CustomDomainCloudfrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    DependsOn: DevPortalSiteS3Bucket
+    Condition: UseCustomDomainName
+    Properties:
+      DistributionConfig:
+        Aliases:
+          - !Ref CustomDomainName
+          - !Join [ '', [ 'www.', !Ref CustomDomainName ] ]
+        DefaultCacheBehavior:
+          ForwardedValues:
+            QueryString: true
+          TargetOriginId: 'dev-portal-site-s3-bucket'
+          ViewerProtocolPolicy: redirect-to-https
+        DefaultRootObject: index.html
+        Enabled: true
+        Origins:
+          - DomainName: !Join [ '', [ !Ref DevPortalSiteS3BucketName, '.s3.amazonaws.com' ] ]
+            Id: 'dev-portal-site-s3-bucket'
+            S3OriginConfig:
+              OriginAccessIdentity: !Join [ '', [ 'origin-access-identity/cloudfront/', !Ref CustomDomainDistributionAccessIdentity ] ]
+
+  CustomDomainDistributionAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Condition: UseCustomDomainName
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Sub 'CloudFront OAI for ${CustomDomainName}'
+
+  CustomDomainHostedZone:
+    Type: AWS::Route53::HostedZone
+    Condition: UseCustomDomainName
+    Properties:
+      Name: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
+
+  CustomDomainRecordSet:
+    Type: AWS::Route53::RecordSetGroup
+    Condition: UseCustomDomainName
+    Properties:
+      HostedZoneName: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
+      RecordSets:
+        - Name: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
+          Type: A
+          AliasTarget:
+            DNSName: !Join [ '', [ !GetAtt CustomDomainCloudfrontDistribution.DomainName, '.' ] ]
+            # this is a "magic string" for using CFN aliases; see this link:
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
+            HostedZoneId: 'Z2FDTNDATAQYW2'
+        - Name: !Join [ '', [ 'www.', !Ref CustomDomainName, '.' ] ]
+          Type: A
+          AliasTarget:
+            DNSName: !Join [ '', [ !GetAtt CustomDomainCloudfrontDistribution.DomainName, '.' ] ]
+            HostedZoneId: 'Z2FDTNDATAQYW2'
 
 Outputs:
   LambdaFunctionConsoleUrl:


### PR DESCRIPTION
The user can now provide a domain name (associated with an ACM cert) as
a parameter override to build out a cloudfront distribution and
associated route53 records. If the parameter override is not provided,
the dev portal is built as previously without a cloudfront distribution
or route53 records.