### PR TITLE
Fix 'untrusted SSL cert' error on custom domain setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ When logged into the developer portal with an account that has a provisioned api
 
 ## Before going to production
 
-You should [request and verify an ACM managed certificate for your custom domain name.](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html) Then, redeploy the CFN stack with the domain name as a parameter override:
+You should [request and verify an ACM managed certificate for your custom domain name.](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html) Then, redeploy the CFN stack with the domain name and ACM cert ARN as parameter overrides:
 
 ```bash
-sam deploy --template-file ./cloudformation/packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts" CustomDomainName="my.acm.managed.domain.name.com"
+sam deploy --template-file ./cloudformation/packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts" CustomDomainName="my.acm.managed.domain.name.com" CustomDomainNameAcmCertArn="arn:aws:acm:us-east-1:111111111111:certificate/12345678-1234-1234-1234-1234567890ab"
 ```
 
 This will create a cloudfront distribution in front of the S3 bucket serving the site, set up a Route53 hosted zone with records aliased to that distribution, and require HTTPS to communicate with the developer portal S3 bucket.

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -44,8 +44,13 @@ Parameters:
     Description: Optionally provide a custom domain name associated with an ACM cert to create a developer portal at that domain name (provide with the format foo.bar.net). Leave blank to create a developer portal without a custom domain name. Standing up a developer portal stack with a custom domain name will take significantly longer than without.
     Default: ''
 
+  CustomDomainNameAcmCertArn:
+    Type: String
+    Description: If you provided a domain name associated with an acm cert, then you must also specify here the acm cert's arn. Leave this blank to create a developer portal without a custom domain name.
+    Default: ''
+
 Conditions:
-  UseCustomDomainName: !Not [ !Equals [!Ref CustomDomainName, ''] ]
+  UseCustomDomainName: !And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]]
 
 Resources:
   ApiGatewayApi:
@@ -853,6 +858,9 @@ Resources:
             Id: 'dev-portal-site-s3-bucket'
             S3OriginConfig:
               OriginAccessIdentity: !Join [ '', [ 'origin-access-identity/cloudfront/', !Ref CustomDomainDistributionAccessIdentity ] ]
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CustomDomainNameAcmCertArn
+          SslSupportMethod: 'sni-only'
 
   CustomDomainDistributionAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity


### PR DESCRIPTION
The cloudfront distribution set up by the CFN stack didn't properly use
the customers' ACM cert, instead using a wildcard cert (*.cloudfront).
This caused browsers to show an 'untrusted SSL cert' error on visiting
the page.