### PR TITLE
Add title to backend API

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -64,6 +64,7 @@ Resources:
       DefinitionBody:
         swagger: 2.0
         info:
+          title: !Join ['', [!Ref 'AWS::StackName', '-backend-api']]
           version: 2016-09-02T22:37:24Z
         basePath: /prod
         schemes:


### PR DESCRIPTION
This will cause it to have a readable name (e.g.,
three-dev-portal-backend-api) instead of being named after the timestamp
(Imported on 2018-10-16T16:5...).