### PR TITLE
Allow users to skip Route53 during domain name creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,17 @@ When logged into the developer portal with an account that has a provisioned api
 
 ## Before going to production
 
-You should [request and verify an ACM managed certificate for your custom domain name.](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html) Then, redeploy the CFN stack with the domain name and ACM cert ARN as parameter overrides:
+You should [request and verify an ACM managed certificate for your custom domain name.](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html) Then, redeploy the CFN stack with the domain name and ACM cert ARN as parameter overrides. Additionally, you can control if Route 53 nameservers are created using the `SkipRoute53NameserverCreation` override. A value of false will result in the creation of a Route 53 hosted zone and record set; true will skip the creation of these resources.
 
 ```bash
-sam deploy --template-file ./cloudformation/packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts" CustomDomainName="my.acm.managed.domain.name.com" CustomDomainNameAcmCertArn="arn:aws:acm:us-east-1:111111111111:certificate/12345678-1234-1234-1234-1234567890ab"
+sam deploy --template-file ./cloudformation/packaged.yaml --stack-name "dev-portal" --capabilities CAPABILITY_NAMED_IAM --parameter-overrides DevPortalSiteS3BucketName="custom-prefix-dev-portal-static-assets" ArtifactsS3BucketName="custom-prefix-dev-portal-artifacts" CustomDomainName="my.acm.managed.domain.name.com" CustomDomainNameAcmCertArn="arn:aws:acm:us-east-1:111111111111:certificate/12345678-1234-1234-1234-1234567890ab" SkipRoute53NameserverCreation="true"
 ```
 
-This will create a cloudfront distribution in front of the S3 bucket serving the site, set up a Route53 hosted zone with records aliased to that distribution, and require HTTPS to communicate with the developer portal S3 bucket.
+This creates a cloudfront distribution in front of the S3 bucket serving the site, optionally sets up a Route53 hosted zone with records aliased to that distribution, and require HTTPS to communicate with the cloudfront distribution.
 
-After the deployment finishes, go to the Route53 console, find the nameservers for the hosted zone created by the deployment, and add those as the nameservers for your domain name through your registrar. The specifics of this process will vary by registrar.
+If you chose `SkipRoute53NameserverCreation=false`, after the deployment finishes, go to the Route53 console, find the nameservers for the hosted zone created by the deployment, and add those as the nameservers for your domain name through your registrar. The specifics of this process will vary by registrar.
+
+If you chose `SkipRoute53NameserverCreation=true`, instead point your nameservers at the cloudfront distribution's URL.
 
 ## Components
 

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -54,8 +54,14 @@ Parameters:
     Description: If you provided a domain name associated with an acm cert, then you must also specify here the acm cert's arn. Leave this blank to create a developer portal without a custom domain name.
     Default: ''
 
+  SkipRoute53NameserverCreation:
+    Type: Boolean
+    Description: Only applicable if creating a custom domain name for your dev portal. If true, skips creating a Route53 HostedZone and RecordSet. You'll need to provide your own nameserver hosting in place of Route53.
+    Default: false
+
 Conditions:
   UseCustomDomainName: !And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]]
+  UseRoute53: !Not [!Ref SkipRoute53NameserverCreation]
 
 Resources:
   ApiGatewayApi:
@@ -881,13 +887,13 @@ Resources:
 
   CustomDomainHostedZone:
     Type: AWS::Route53::HostedZone
-    Condition: UseCustomDomainName
+    Condition: !And [ UseCustomDomainName, UseRoute53 ]
     Properties:
       Name: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
 
   CustomDomainRecordSet:
     Type: AWS::Route53::RecordSetGroup
-    Condition: UseCustomDomainName
+    Condition: !And [ UseCustomDomainName, UseRoute53]
     Properties:
       HostedZoneName: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
       RecordSets:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -55,13 +55,15 @@ Parameters:
     Default: ''
 
   SkipRoute53NameserverCreation:
-    Type: Boolean
+    Type: String
     Description: Only applicable if creating a custom domain name for your dev portal. If true, skips creating a Route53 HostedZone and RecordSet. You'll need to provide your own nameserver hosting in place of Route53.
-    Default: false
+    Default: 'false'
 
 Conditions:
   UseCustomDomainName: !And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]]
-  UseRoute53: !Not [!Ref SkipRoute53NameserverCreation]
+  # the second clause is a copy of the UseCustomDomainName condition
+  # re-using it doesn't seem possible?
+  UseRoute53: !And [!Equals [!Ref SkipRoute53NameserverCreation, 'false'], !And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]]]
 
 Resources:
   ApiGatewayApi:
@@ -887,13 +889,13 @@ Resources:
 
   CustomDomainHostedZone:
     Type: AWS::Route53::HostedZone
-    Condition: !And [ UseCustomDomainName, UseRoute53 ]
+    Condition: UseRoute53
     Properties:
       Name: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
 
   CustomDomainRecordSet:
     Type: AWS::Route53::RecordSetGroup
-    Condition: !And [ UseCustomDomainName, UseRoute53]
+    Condition: UseRoute53
     Properties:
       HostedZoneName: !Join [ '', [ !Ref CustomDomainName, '.' ] ]
       RecordSets:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -57,7 +57,7 @@ Parameters:
   SkipRoute53NameserverCreation:
     Type: String
     Description: Only applicable if creating a custom domain name for your dev portal. If true, skips creating a Route53 HostedZone and RecordSet. You'll need to provide your own nameserver hosting in place of Route53.
-    Default: 'false'
+    Default: 'true'
 
 Conditions:
   UseCustomDomainName: !And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]]


### PR DESCRIPTION
Some customers will have their own nameserver hosting and would rather
not use Route53. This option will support them out of the box.