### PR TITLE
Fix redirects on custom domains

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -311,12 +311,7 @@ Resources:
           - RoutingRuleCondition:
               HttpErrorCodeReturnedEquals: 403
             RedirectRule:
-              HostName: !Join
-                - ''
-                - - !Ref DevPortalSiteS3BucketName
-                  - .s3-website-
-                  - !Ref 'AWS::Region'
-                  - .amazonaws.com
+              HostName: !If [ UseCustomDomainName, !Ref CustomDomainName, !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3-website-', !Ref 'AWS::Region', '.amazonaws.com']]]
               ReplaceKeyPrefixWith: '#!/'
 
   ArtifactsS3Bucket:
@@ -865,10 +860,10 @@ Resources:
         DefaultRootObject: index.html
         Enabled: true
         Origins:
-          - DomainName: !Join [ '', [ !Ref DevPortalSiteS3BucketName, '.s3.amazonaws.com' ] ]
+          - DomainName: !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3-website-', !Ref 'AWS::Region', '.amazonaws.com']]
             Id: 'dev-portal-site-s3-bucket'
-            S3OriginConfig:
-              OriginAccessIdentity: !Join [ '', [ 'origin-access-identity/cloudfront/', !Ref CustomDomainDistributionAccessIdentity ] ]
+            CustomOriginConfig:
+              OriginProtocolPolicy: 'http-only'
         ViewerCertificate:
           AcmCertificateArn: !Ref CustomDomainNameAcmCertArn
           SslSupportMethod: 'sni-only'


### PR DESCRIPTION
Dev portal hosted on a custom domain used to redirect to an XML page
instead of showing the (client-side) 404. This was because the
cloudfront origin was set to s3's bucket URL, not s3's website URL (yes,
an S3 bucket has both). This commit fixes that behavior.