### PR TITLE
Add get-dependencies script

### DIFF
--- a/dev-portal/package.json
+++ b/dev-portal/package.json
@@ -20,6 +20,7 @@
     "swagger-ui": "^3.19.3"
   },
   "scripts": {
+    "get-dependencies": "npm install; npm run build",
     "start": "react-scripts start",
     "build": "react-scripts build; rm -rf ../lambdas/static-asset-uploader/build; cp -r ./build ../lambdas/static-asset-uploader",
     "deploy": "node ./scripts/deploy-stack.js",

--- a/lambdas/backend/package.json
+++ b/lambdas/backend/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "aws-serverless-dev-portal-example",
+  "name": "serverless-developer-backend",
   "version": "1.0.0",
-  "description": "Example application for running a Serverless Developer Portal with API Gateway and Lambda",
+  "description": "developer portal component responsible for backend application logic",
   "main": "index.js",
   "config": {},
   "scripts": {
-    "local": "node ./express-server-local"
+    "local": "node ./express-server-local",
+    "get-dependencies": "npm install"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/lambdas/catalog-updater/package.json
+++ b/lambdas/catalog-updater/package.json
@@ -1,10 +1,12 @@
 {
   "name": "serverless-developer-portal-catalog-updater",
   "version": "1.0.0",
-  "description": "API Gateway Serverless Developer Portal component responsible for updating the catalog of usage plans and swagger files",
+  "description": "developer portal component responsible for updating the catalog of usage plans and swagger files",
   "main": "index.js",
   "config": {},
-  "scripts": {},
+  "scripts": {
+    "get-dependencies": "npm install"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.6.7",

--- a/lambdas/listener/package.json
+++ b/lambdas/listener/package.json
@@ -1,10 +1,12 @@
 {
-  "name": "aws-serverless-dev-portal-example",
+  "name": "serverless-developer-portal-marketplace-listener",
   "version": "1.0.0",
-  "description": "Example application for running a Serverless Developer Portal with API Gateway and Lambda",
+  "description": "developer portal component responsible for aws marketplace integration",
   "main": "index.js",
   "config": {},
-  "scripts": {},
+  "scripts": {
+    "get-dependencies": "npm install"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.6.7"

--- a/lambdas/static-asset-uploader/package.json
+++ b/lambdas/static-asset-uploader/package.json
@@ -1,10 +1,12 @@
 {
   "name": "serverless-developer-portal-static-asset-uploader",
   "version": "1.0.0",
-  "description": "API Gateway Serverless Developer Portal component responsible for uploading static assets to S3",
+  "description": "developer portal component responsible for uploading static assets to S3",
   "main": "index.js",
   "config": {},
-  "scripts": {},
+  "scripts": {
+    "get-dependencies": "npm install"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "2.1.0",
   "description": "Serverless Developer Portal for API Gateway",
   "main": "lambda.js",
-  "scripts": {},
+  "scripts": {
+    "get-dependencies": "npm run get-dev-portal-dependencies; npm run get-lambda-dependencies;",
+    "get-lambda-dependencies": "find lambdas/*/package.json -type f -exec sh -c 'cd $(dirname {}); npm run get-dependencies' \\;",
+    "get-dev-portal-dependencies": "(cd dev-portal; npm run get-dependencies)"
+  },
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {}


### PR DESCRIPTION
This adds the first step towards usable release-tooling. `npm run
get-dependencies` from the top level directory will install dev portal
dependencies, build the dev portal, and install all the lambda
dependencies.