### PR TITLE
Fix SAR blocking issue

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -842,7 +842,7 @@ Resources:
           StaticBucketName: !Ref ArtifactsS3BucketName
 
   StaticAssetUploader:
-    Type: Custom::LambdaDependency
+    Type: AWS::CloudFormation::CustomResource
     DependsOn: ArtifactsS3Bucket
     Properties:
       ServiceToken: !GetAtt StaticAssetUploaderLambdaFunction.Arn


### PR DESCRIPTION
SAR only recognizes custom resources defined as
"AWS::CloudFormation::CustomResource", but we were using the newer,
shorter syntax of "Custom::ArbitraryString".