### PR TITLE
Add installing dev dependencies to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - "node"
+
+before_install:
+  - cd dev-portal
+  - npm install --only=dev
+  - cd ..
+  - npm install --only=dev

--- a/dev-portal/package.json
+++ b/dev-portal/package.json
@@ -14,7 +14,6 @@
     "react-dom": "^16.5.2",
     "react-markdown": "^4.0.3",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "2.0.3",
     "semantic-ui-css": "^2.4.0",
     "semantic-ui-react": "^0.82.5",
     "swagger-ui": "^3.19.3"
@@ -39,6 +38,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "mobx-react-devtools": "^6.0.3"
+    "mobx-react-devtools": "^6.0.3",
+    "react-scripts": "2.0.3"
   }
 }


### PR DESCRIPTION
Also make react-scripts a dev dependency, since it's needed to run
tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
