### PR TITLE
Remove timestamp or version

### DIFF
--- a/dev-portal/src/components/SwaggerUiLayout.jsx
+++ b/dev-portal/src/components/SwaggerUiLayout.jsx
@@ -35,12 +35,16 @@ const InfoReplacement = observer(({ specSelectors }) => {
           <Header as='h1'>{store.api.swagger.info.title}</Header>
           <div style={{ display: "flex" }}>
             <div style={{ marginRight: "20px" }}>
-              <p style={{ fontWeight: "bold" }}>Version</p>
+              {store.api.generic && (
+                <p style={{ fontWeight: "bold" }}>Version</p>
+              )}
               <p style={{ fontWeight: "bold" }}>Endpoint</p>
               {/* <p style={{ fontWeight: "bold" }}>Usage Plan</p> */}
             </div>
             <div>
-              <p>{store.api.swagger.info.version}</p>
+              {store.api.generic && (
+                <p>{store.api.swagger.info.version}</p>
+              )}
               <p>https://{host}{basePath}</p>
               {/* <p>{store.api.usagePlan.name}</p> */}
             </div>


### PR DESCRIPTION
*Description of changes:*

Hide the version for API Gateway API's b.c the version is a timestamp, and that's not really useful. (Closes #97.)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
