### PR TITLE
Catalog generation fix

### DIFF
--- a/dev-portal/src/pages/Apis.jsx
+++ b/dev-portal/src/pages/Apis.jsx
@@ -52,10 +52,10 @@ export default observer(class ApisPage extends React.Component {
     let errorHeader
     let errorBody 
 
-    if (store.apiList && store.apiList.length === 0) {
+    if (!store.apiList.apiGateway.length && !store.apiList.generic.length) {
       errorHeader = `No APIs Published`
       errorBody = `Your administrator hasn't added any APIs to your account. Please contact them to publish an API.`
-    } else if (!store.api && store.apiList && store.apiList.length) {
+    } else if (!store.api) {
       errorHeader = `No Such API`
       errorBody = `The selected API doesn't exist.`
     }

--- a/dev-portal/src/services/api-catalog.js
+++ b/dev-portal/src/services/api-catalog.js
@@ -37,16 +37,19 @@ export function updateUsagePlansAndApisList(bustCache = false) {
     .then(apiGatewayClient => apiGatewayClient.get('/catalog', {}, {}, {}))
     .then(({ data = [] }) => {
       store.usagePlans = data.apiGateway
-
-      if (!store.apiList) store.apiList = {}
-      store.apiList.apiGateway = getApiGatewayApisFromUsagePlans(store.usagePlans) // MUST create
-      store.apiList.generic = data.generic
-      store.apiList.loaded = true
+      store.apiList = {
+        loaded: true,
+        apiGateway: getApiGatewayApisFromUsagePlans(store.usagePlans), // MUST create
+        generic: data.generic
+      }
     })
     .catch(() => {
-      store.apiList = null
       store.usagePlans = null
-      store.apiList.loaded = true
+      store.apiList = {
+        loaded: true,
+        apiGateway: [],
+        generic: []
+      }
     })
 }
 let catalogPromiseCache // WARNING: Don't touch this. Should only be used by updateCatalogAndApisList.

--- a/lambdas/catalog-updater/index.js
+++ b/lambdas/catalog-updater/index.js
@@ -180,17 +180,14 @@ function usagePlanToCatalogObject(usagePlan, swaggerFileReprs) {
   _.forEach(usagePlan.apiStages, (apiStage) => {
     let api = {}
 
-    _.chain(swaggerFileReprs)
-      .find((swaggerFileRepr) => {
-        return swaggerFileRepr.apiStageKey === `${apiStage.apiId}_${apiStage.stage}`
+    swaggerFileReprs
+      .filter(swaggerFileRepr => swaggerFileRepr.apiStageKey === `${apiStage.apiId}_${apiStage.stage}`)
+      .forEach(swaggerFileRepr => {
+        api.swagger = swaggerFileRepr.body
+        api.id = apiStage.apiId
+        api.stage = apiStage.stage
+        catalogObject.apis.push(api)
       })
-      .tap((swaggerFileRepr) => {
-          api.swagger = swaggerFileRepr.body
-          api.id = apiStage.apiId
-          api.stage = apiStage.stage
-          catalogObject.apis.push(api)
-      })
-      .value()
   })
 
   return catalogObject
@@ -270,6 +267,7 @@ exports = module.exports = {
   swaggerFileFilter,
   getSwaggerFile,
   buildCatalog,
+  usagePlanToCatalogObject,
   s3: new AWS.S3(),
   gateway: new AWS.APIGateway(),
   handler,


### PR DESCRIPTION
4c20348 - Basically, we were correctly filtering out every non-apigateway api, and then trying to 'tap' on an undefined value. I moved it to always stay an array -- if `filter` finds nothing, it returns a blank array and `forEach` never runs.


db22f0d - The APIs page was still using the flattened list pattern, and was never hitting the error cases. I also changed `updateUsagePlansAndApisList` to set apiList to the default values on fail.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
