### PR TITLE
Organise Parameters

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -6,7 +6,7 @@ Description: My Dev Portal Stack
 Parameters:
   ArtifactsS3BucketName:
     Type: String
-    Description: The S3 bucket in which the Lambda function code is stored. Bucket
+    Description: The S3 bucket in which the Open API documents are stored. Bucket
       names are globally unique, so you must change this.
 
   DevPortalSiteS3BucketName:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -39,11 +39,6 @@ Parameters:
     Description: The name for your Cognito Identity Pool.
     Default: "DevPortalUserPool"
 
-  AWSRegion:
-    Type: String
-    Description: The region to deploy to.
-    Default: "us-east-1"
-
   CustomDomainName:
     Type: String
     Description: Optionally provide a custom domain name associated with an ACM cert to create a developer portal at that domain name (provide with the format foo.bar.net). Leave blank to create a developer portal without a custom domain name. Standing up a developer portal stack with a custom domain name will take significantly longer than without.

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -3,6 +3,35 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 
 Description: My Dev Portal Stack
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -
+        Label:
+          default: "Dev Portal Content Configuration"
+        Parameters:
+          - ArtifactsS3BucketName
+          - DevPortalSiteS3BucketName
+          - StaticAssetRebuildToken
+          - StaticAssetRebuildMode
+      -
+        Label:
+          default: "Dev Portal Customer Configuration"
+        Parameters:
+          - CognitoIdentityPoolName
+          - DevPortalCustomersTableName
+      -
+        Label:
+          default: "Subscription Notification Configuration"
+        Parameters:
+          - MarketplaceSubscriptionTopicProductCode
+      -
+        Label:
+          default: "Custom Domain Configuration"
+        Parameters:
+          - CustomDomainName
+          - CustomDomainNameAcmCertArn
+          - UseRoute53Nameservers
 Parameters:
   ArtifactsS3BucketName:
     Type: String


### PR DESCRIPTION
*Issue #130  , if available:*

Addresses part of issue #130

*Description of changes:*

Organised parameters into ParameterGroups for improved display when deploying the stack via the CloudFormation UI
Fixed an incorrect parameter description
Removed an unused parameter - AWSRegion

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
