### PR TITLE
Fix hosted signout redirect error

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -915,7 +915,7 @@ Resources:
       UserPoolClientId: !Ref CognitoUserPoolClient
       SupportedIdentityProviders: [ "COGNITO" ] # should (eventually) allow people to add values
       CallbackURL: !Join ['', [ 'https://', !If [ UseCustomDomainName, !Ref CustomDomainName, !GetAtt DefaultCloudfrontDistribution.DomainName ], '/login' ]]
-      LogoutURL: !Join ['', [ 'https://', !If [ UseCustomDomainName, !Ref CustomDomainName, !GetAtt DefaultCloudfrontDistribution.DomainName ], '/logout' ]]
+      LogoutURL: !Join ['', [ 'https://', !If [ UseCustomDomainName, !Ref CustomDomainName, !GetAtt DefaultCloudfrontDistribution.DomainName ]]]
       AllowedOAuthFlowsUserPoolClient: true
       AllowedOAuthFlows: [ "implicit" ]
       AllowedOAuthScopes: [ "openid" ]


### PR DESCRIPTION
Previously, logging off when using hosted signout left the user on a
cognito hosted error page with an error message that the redirectUri was
not defined. This fixes it. According to this doc:
https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html#get-logout-request-parameters

The redirectUri in the request to log out must match the one in the
cognito user pool settings. Since the request query-string specified
<devportalURI> and the user pool setting specified
<devportalURI>/logout, the hosted sign-in page couldn't associate them
correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
