### PR TITLE
Remove duplicate Region -> S3 Website URL mapping

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -144,49 +144,6 @@ Mappings:
     us-gov-west-1:
       s3Url: '.s3-website-us-gov-west-1.amazonaws.com'
 
-Mappings:
-  # this information comes from these locations, and will need to be kept manually up to date:
-  # https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
-  # https://docs.aws.amazon.com/govcloud-us/latest/ug-west/using-govcloud-endpoints.html
-  # http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region
-  RegionSpecificConfig:
-    us-east-2:
-      s3Url: '.s3-website.us-east-2.amazonaws.com'
-    us-east-1:
-      s3Url: '.s3-website-us-east-1.amazonaws.com'
-    us-west-1:
-      s3Url: '.s3-website-us-west-1.amazonaws.com'
-    us-west-2:
-      s3Url: '.s3-website-us-west-2.amazonaws.com'
-    ap-south-1:
-      s3Url: '.s3-website.ap-south-1.amazonaws.com'
-    ap-northeast-3:
-      s3Url: '.s3-website.ap-northeast-3.amazonaws.com'
-    ap-northeast-2:
-      s3Url: '.s3-website.ap-northeast-2.amazonaws.com'
-    ap-southeast-1:
-      s3Url: '.s3-website-ap-southeast-1.amazonaws.com'
-    ap-southeast-2:
-      s3Url: '.s3-website-ap-southeast-2.amazonaws.com'
-    ap-northeast-1:
-      s3Url: '.s3-website-ap-northeast-1.amazonaws.com'
-    ca-central-1:
-      s3Url: '.s3-website.ca-central-1.amazonaws.com'
-    cn-northwest-1:
-      s3Url: '.s3-website.cn-northwest-1.amazonaws.com.cn'
-    eu-central-1:
-      s3Url: '.s3-website.eu-central-1.amazonaws.com'
-    eu-west-1:
-      s3Url: '.s3-website-eu-west-1.amazonaws.com'
-    eu-west-2:
-      s3Url: '.s3-website.eu-west-2.amazonaws.com'
-    eu-west-3:
-      s3Url: '.s3-website.eu-west-3.amazonaws.com'
-    sa-east-1:
-      s3Url: '.s3-website-sa-east-1.amazonaws.com'
-    us-gov-west-1:
-      s3Url: '.s3-website-us-gov-west-1.amazonaws.com'
-
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The map of Region -> S3 Website URL is defined twice. See above the removed lines.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
