### PR TITLE
Customer feedback mechanism

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -888,7 +888,7 @@ Resources:
           CustomersTableName: !Ref DevPortalCustomersTableName
           FeedbackTableName: !Ref DevPortalFeedbackTableName
           FeedbackSnsTopicArn:
-            Fn::If: [EnableFeedbackSubmission, !Ref FeedbackSubmittedSNSTopic, '']
+            !If [EnableFeedbackSubmission, !Ref FeedbackSubmittedSNSTopic, '']
 
       # Adds the API as a trigger
       Events:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -32,6 +32,13 @@ Metadata:
           - CustomDomainName
           - CustomDomainNameAcmCertArn
           - UseRoute53Nameservers
+      -
+        Label:
+          default: "Dev Portal Customer Feedback Configuration"
+        Parameters:
+          - DevPortalAdminEmail
+          - DevPortalFeedbackTableName
+
 Parameters:
   ArtifactsS3BucketName:
     Type: String
@@ -46,7 +53,17 @@ Parameters:
   DevPortalCustomersTableName:
     Type: String
     Description: The name of the DynamoDB Customers table.
-    Default: "DevPortalCustomers"
+    Default: DevPortalCustomers
+
+  DevPortalAdminEmail:
+    Type: String
+    Description: The email address where user submitted feedback notifications get sent.
+    Default: ''
+
+  DevPortalFeedbackTableName:
+    Type: String
+    Description: The name of the DynamoDB table storing feedback submitted by users.
+    Default: DevPortalFeedback
 
   StaticAssetRebuildToken:
     Type: String
@@ -61,12 +78,12 @@ Parameters:
   MarketplaceSubscriptionTopicProductCode:
     Type: String
     Description: The marketplace SNS topic suffix for subscription/unsubscription events
-    Default: "DevPortalMarketplaceSubscriptionTopic"
+    Default: DevPortalMarketplaceSubscriptionTopic
 
   CognitoIdentityPoolName:
     Type: String
     Description: The name for your Cognito Identity Pool.
-    Default: "DevPortalUserPool"
+    Default: DevPortalUserPool
 
   CognitoDomainNameOrPrefix:
     Type: String
@@ -100,6 +117,7 @@ Conditions:
   NoCustomDomainName: !Not [ !Condition UseCustomDomainName ]
   UseRoute53: !And [!Equals [!Ref UseRoute53Nameservers, 'true'], !Condition UseCustomDomainName]
   UseCognitoHostedUI: !Not [!Equals [!Ref CognitoDomainNameOrPrefix, '']]
+  EnableFeedbackSubmission: !Not [!Equals [!Ref DevPortalAdminEmail, '']]
 
 Mappings:
   # this information comes from these locations, and will need to be kept manually up to date:
@@ -329,6 +347,58 @@ Resources:
                 requestTemplates:
                   application/json: "{\"statusCode\": 200}"
                 type: mock
+          /feedback:
+            get:
+              produces:
+              - application/json
+              responses: {}
+              x-amazon-apigateway-integration:
+                uri: !Join
+                  - ''
+                  - - !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function
+                    - :${stageVariables.DevPortalFunctionName}/invocations
+                httpMethod: POST
+                type: aws_proxy
+            post:
+              produces:
+              - application/json
+              responses: {}
+              x-amazon-apigateway-integration:
+                uri: !Join
+                  - ''
+                  - - !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function
+                    - :${stageVariables.DevPortalFunctionName}/invocations
+                httpMethod: POST
+                type: aws_proxy
+            options:
+              consumes:
+              - application/json
+              produces:
+              - application/json
+              responses:
+                '200':
+                  description: 200 response
+                  schema:
+                    $ref: "#/definitions/Empty"
+                  headers:
+                    Access-Control-Allow-Origin:
+                      type: string
+                    Access-Control-Allow-Methods:
+                      type: string
+                    Access-Control-Allow-Headers:
+                      type: string
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: 200
+                    responseParameters:
+                      method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
+                      method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+                      method.response.header.Access-Control-Allow-Origin: "'*'"
+                passthroughBehavior: when_no_match
+                requestTemplates:
+                  application/json: "{\"statusCode\": 200}"
+                type: mock
           /{proxy+}:
             x-amazon-apigateway-any-method:
               x-amazon-apigateway-auth:
@@ -448,6 +518,39 @@ Resources:
           ReadCapacityUnits: '5'
           WriteCapacityUnits: '5'
 
+  FeedbackTable:
+    Type: AWS::DynamoDB::Table
+    Condition: EnableFeedbackSubmission
+    Properties:
+      TableName: !Ref DevPortalFeedbackTableName
+      AttributeDefinitions:
+      - AttributeName: Id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: Id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
+      GlobalSecondaryIndexes:
+      - IndexName: FeedbackIdIndex
+        KeySchema:
+        - AttributeName: Id
+          KeyType: HASH
+        Projection:
+          ProjectionType: KEYS_ONLY
+        ProvisionedThroughput:
+          ReadCapacityUnits: '5'
+          WriteCapacityUnits: '5'
+
+  FeedbackSubmittedSNSTopic:
+    Type: AWS::SNS::Topic
+    Condition: EnableFeedbackSubmission
+    Properties:
+      Subscription:
+      - Endpoint: !Ref DevPortalAdminEmail
+        Protocol: email
+
   BackendLambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -514,6 +617,30 @@ Resources:
                 - :table/
                 - !Ref CustomersTable
                 - /index/MarketplaceCustomerIdIndex
+          - !If
+            - EnableFeedbackSubmission
+            - Effect: Allow
+              Action:
+              - dynamodb:Scan
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+              - dynamodb:DeleteItem
+              Resource: !Join
+                - ''
+                - - 'arn:aws:dynamodb:'
+                  - !Ref 'AWS::Region'
+                  - ':'
+                  - !Ref 'AWS::AccountId'
+                  - :table/
+                  - !Ref FeedbackTable
+            - !Ref 'AWS::NoValue'
+          - !If
+            - EnableFeedbackSubmission
+            - Effect: Allow
+              Action:
+              - sns:Publish
+              Resource: !Ref FeedbackSubmittedSNSTopic
+            - !Ref 'AWS::NoValue'
 
   CognitoStrategyLambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -759,6 +886,9 @@ Resources:
           WEBSITE_BUCKET_NAME: !Ref DevPortalSiteS3BucketName
           StaticBucketName: !Ref ArtifactsS3BucketName
           CustomersTableName: !Ref DevPortalCustomersTableName
+          FeedbackTableName: !Ref DevPortalFeedbackTableName
+          FeedbackSnsTopicArn:
+            Fn::If: [EnableFeedbackSubmission, !Ref FeedbackSubmittedSNSTopic, '']
 
       # Adds the API as a trigger
       Events:
@@ -1041,6 +1171,7 @@ Resources:
       MarketplaceSuffix: !Ref MarketplaceSubscriptionTopicProductCode
       RebuildToken: !Ref StaticAssetRebuildToken
       RebuildMode: !Ref StaticAssetRebuildMode
+      FeedbackEnabled: !If [ EnableFeedbackSubmission, 'true', 'false' ]
 
   CustomDomainCloudfrontDistribution:
     Type: AWS::CloudFront::Distribution

--- a/dev-portal/src/components/Feedback.jsx
+++ b/dev-portal/src/components/Feedback.jsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { Button, Form, Modal, TextArea, Message } from 'semantic-ui-react'
+import { submitFeedback } from 'services/feedback'
+
+const initialState = {
+  message: '',
+  formOpen: false,
+  feedbackSubmitted: false
+}
+
+class Feedback extends React.PureComponent {
+  constructor(props) {
+    super(props)
+
+    this.state = initialState
+  }
+
+  openModal = () => {
+    this.setState({
+      formOpen: true
+    })
+  }
+
+  closeModal = () => {
+    this.setState(initialState)
+  }
+
+  handleSubmit = () => {
+    const { message } = this.state
+    submitFeedback(message).then(() => {
+      this.setState({
+        feedbackSubmitted: true
+      })
+    })
+  }
+
+  render() {
+    const { 
+      message,
+      formOpen,
+      feedbackSubmitted
+    } = this.state
+    
+    return (
+      <Modal 
+        closeIcon
+        centered={false}
+        size='tiny' 
+        open={formOpen}
+        onClose={this.closeModal}
+        trigger={
+          <div style={{ 
+            display: 'block', 
+            position: 'fixed', 
+            top: '50%', 
+            right: '-62px', // Adjusted for rotation
+            transform: 'rotate(90deg)'
+          }}>
+            <Button style={{
+              borderTopLeftRadius: '0',
+              borderTopRightRadius: '0'
+            }} onClick={this.openModal}><i className="envelope outline icon"></i>Got an opinon?</Button>
+          </div>
+        }>
+        <Modal.Header>Let us know!</Modal.Header>
+        <Modal.Content>
+          {!feedbackSubmitted &&
+            <Form>
+              <Form.Field>
+                <TextArea value={message} onChange={(e) => this.setState({ message: e.target.value})} />
+              </Form.Field>
+              <Button type='submit' positive onClick={this.handleSubmit}>Submit</Button>
+            </Form>
+          }
+          {feedbackSubmitted &&
+            <Message positive>
+              <p>Thanks for your feedback</p>
+            </Message>
+          }
+        </Modal.Content>
+      </Modal>
+    )
+  }
+}
+
+export default Feedback

--- a/dev-portal/src/index.js
+++ b/dev-portal/src/index.js
@@ -20,9 +20,15 @@ import Apis from 'pages/Apis'
 // components
 import AlertPopup from 'components/AlertPopup'
 import NavBar from 'components/NavBar'
+import Feedback from './components/Feedback'
 
 import { init, login, logout } from 'services/self'
 import './index.css';
+
+// TODO: Feedback should be enabled if
+// the following is true && the current
+// user is not an administrator
+const feedbackEnabled = window.config.feedbackEnabled
 
 class App extends React.Component {
   constructor() {
@@ -53,6 +59,7 @@ class App extends React.Component {
             <Route path="/logout" render={() => (logout(), <Redirect to="/" />)}/>
             <Route component={() => <h2>Page not found</h2>} />
           </Switch>
+          {feedbackEnabled && <Feedback /> }
         </React.Fragment>
       </BrowserRouter>
     )

--- a/dev-portal/src/services/feedback.js
+++ b/dev-portal/src/services/feedback.js
@@ -1,0 +1,8 @@
+import { apiGatewayClient } from './api'
+
+export const submitFeedback = (message) => {
+  return apiGatewayClient()
+          .then(client => {
+            return client.post('/feedback', {}, { message }, {})
+          })
+}

--- a/lambdas/backend/__tests__/feedback-controller-test.js
+++ b/lambdas/backend/__tests__/feedback-controller-test.js
@@ -1,0 +1,81 @@
+const promiser = require('../../setup-jest').promiser
+const controller = require('../_common/feedback-controller')
+
+const userId = 'test-id'
+const message = 'your site is really cool'
+
+describe('submitFeedback', () => {
+  test('should call dynamoDb.put', async () => {
+    controller.dynamoDb.put = jest.fn().mockReturnValue(promiser())
+
+    const expectedInputs = {
+      UserId: userId,
+      Message: message
+    }
+
+    await controller.submitFeedback(userId, message)
+
+    expect(controller.dynamoDb.put).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      Item: expect.objectContaining(expectedInputs)
+    }))
+  })
+
+  test('should call sns.publish', async () => {
+    controller.sns.publish = jest.fn().mockReturnValue(promiser())
+    controller.dynamoDb.put = jest.fn().mockReturnValue(promiser())
+
+    const expectedInputs = {
+      Subject: 'Received customer feedback on your developer portal',
+      Message: message
+    }
+
+    await controller.submitFeedback(userId, message)
+
+    expect(controller.sns.publish).toHaveBeenNthCalledWith(1, expect.objectContaining(expectedInputs))
+  })
+
+  test('should not publish to sns topic if save to dynamo fails', async () => {
+    controller.dynamoDb.put = jest.fn().mockReturnValue(promiser(null, 'error'))
+
+    await controller.submitFeedback(userId, message)
+
+    expect(controller.dynamoDb.put).toHaveBeenCalledTimes(1)
+    expect(controller.sns.publish).not.toHaveBeenCalled()
+  })
+})
+
+describe('fetchFeedback', async () => {
+  test('should paginate when necessary', async () => {
+    const expectedOutput = [
+      {
+        Message: 'message-1',
+        UserId: 'user-1'
+      },
+      {
+        Message: 'message-2',
+        UserId: 'user-2'
+      }
+    ]
+
+    controller.dynamoDb.scan = jest
+      .fn()
+      .mockReturnValueOnce(promiser({
+        Items: [{
+          Message: 'message-1',
+          UserId: 'user-1'
+        }],
+        LastEvaluatedKey: 'key'
+      }))
+      .mockReturnValueOnce(promiser({
+        Items: [{
+          Message: 'message-2',
+          UserId: 'user-2'
+        }]
+      }))
+
+      const result = await controller.fetchFeedback()
+      
+      expect(controller.dynamoDb.scan).toHaveBeenCalledTimes(2)
+      expect(result).toEqual(expectedOutput)
+  })
+})

--- a/lambdas/backend/__tests__/feedback-controller-test.js
+++ b/lambdas/backend/__tests__/feedback-controller-test.js
@@ -7,6 +7,7 @@ const message = 'your site is really cool'
 describe('submitFeedback', () => {
   test('should call dynamoDb.put', async () => {
     controller.dynamoDb.put = jest.fn().mockReturnValue(promiser())
+    controller.sns.publish = jest.fn().mockReturnValue(promiser())
 
     const expectedInputs = {
       UserId: userId,
@@ -37,7 +38,11 @@ describe('submitFeedback', () => {
   test('should not publish to sns topic if save to dynamo fails', async () => {
     controller.dynamoDb.put = jest.fn().mockReturnValue(promiser(null, 'error'))
 
-    await controller.submitFeedback(userId, message)
+    try {
+      await controller.submitFeedback(userId, message)
+    } catch (err) {
+      // expected since we threw the 'error' above
+    }
 
     expect(controller.dynamoDb.put).toHaveBeenCalledTimes(1)
     expect(controller.sns.publish).not.toHaveBeenCalled()

--- a/lambdas/backend/_common/feedback-controller.js
+++ b/lambdas/backend/_common/feedback-controller.js
@@ -60,17 +60,16 @@ const saveToDynamo = function(cognitoIdentityId, message) {
   return dynamoDb.put(putParams).promise()
 }
 
-const submitFeedback = function(cognitoIdentityId, message, error, callback) {
-  saveToDynamo(cognitoIdentityId, message)
-    .then(() => {
-      publishToSnsTopic(message)
-        .then((response) => {
-          callback(response)
-        })
-    })
-    .catch((err) => {
-      error(err)
-    })
+const submitFeedback = function(cognitoIdentityId, message) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      await saveToDynamo(cognitoIdentityId, message)
+      await publishToSnsTopic(message)
+      resolve()
+    } catch (err) {
+      reject(err)
+    }
+  })
 }
 
 module.exports = {

--- a/lambdas/backend/_common/feedback-controller.js
+++ b/lambdas/backend/_common/feedback-controller.js
@@ -1,0 +1,74 @@
+const AWS = require('aws-sdk')
+
+const sns = new AWS.SNS()
+const dynamoDb = new AWS.DynamoDB.DocumentClient()
+
+const feedbackTable = process.env.FeedbackTableName || 'DevPortalFeedback'
+const feedbackTopicArn = process.env.FeedbackSnsTopicArn || ''
+
+const fetchFeedback = function(error, callback) {
+  const scanParams = {
+    TableName: feedbackTable
+  }
+
+  const items = []
+  return dynamoDb.scan(scanParams, function scanUntilDone(err, data) {
+    if (err) {
+      error(err)
+    } else if (data.LastEvaluatedKey) {
+        scanParams.ExclusiveStartKey = data.LastEvaluatedKey;
+        dynamoDb.scan(scanParams, scanUntilDone);
+    } else {
+      callback(items)
+    }
+  })
+}
+
+const publishToSnsTopic = function (message) {
+  const params = {
+    Subject: `Received customer feedback on your developer portal`,
+    Message: message,
+    TopicArn: feedbackTopicArn
+  }
+
+  return sns.publish(params).promise()
+}
+
+const saveToDynamo = function(cognitoIdentityId, message) {
+  const time = new Date().toUTCString()
+
+  // primary key
+  const key = `${cognitoIdentityId}-${time}`
+
+  const putParams = {
+    TableName: feedbackTable,
+    Item: {
+      // structure of ddb record
+      Id: key,
+      UserId: cognitoIdentityId,
+      Message: message,
+      Time: time,
+      Status: 'RECEIVED'
+    }
+  }
+
+  return dynamoDb.put(putParams).promise()
+}
+
+const submitFeedback = function(cognitoIdentityId, message, error, callback) {
+  saveToDynamo(cognitoIdentityId, message)
+    .then(() => {
+      publishToSnsTopic(message)
+        .then((response) => {
+          callback(response)
+        })
+    })
+    .catch((err) => {
+      error(err)
+    })
+}
+
+module.exports = {
+  fetchFeedback,
+  submitFeedback
+}

--- a/lambdas/backend/express-route-handlers.js
+++ b/lambdas/backend/express-route-handlers.js
@@ -270,19 +270,12 @@ function getFeedback(req, res) {
 function postFeedback(req, res) {
     const cognitoIdentityId = getCognitoIdentityId(req)
 
-    function error(data) {
-        console.log(`error: ${data}`)
-        res.status(500).json(data)
-    }
-
-    function success(data) {
-        res.status(200).json(data)
-    }
-
     if (!feedbackEnabled) {
         res.status(401).json("Customer feedback not enabled")
     } else {
-        feedbackController.submitFeedback(cognitoIdentityId, req.body.message, error, success)
+        feedbackController.submitFeedback(cognitoIdentityId, req.body.message)
+            .then(() => res.status(200).json('success'))
+            .catch((err) => res.status(500).json(err))
     }
 }
 

--- a/lambdas/backend/express-server.js
+++ b/lambdas/backend/express-server.js
@@ -6,7 +6,6 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const cors = require('cors')
-const util = require('util')
 const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware')
 const handlers = require('./express-route-handlers.js')
 
@@ -26,6 +25,9 @@ app.get('/subscriptions/:usagePlanId/usage', handlers.getUsage)
 app.delete('/subscriptions/:usagePlanId', handlers.deleteSubscription)
 app.post('/marketplace-confirm/:usagePlanId', handlers.postMarketplaceConfirm)
 app.put('/marketplace-subscriptions/:usagePlanId', handlers.putMarketplaceSubscription)
+app.get('/feedback', handlers.getFeedback)
+app.post('/feedback', handlers.postFeedback)
+
 
 // The aws-serverless-express library creates a server and listens on a Unix
 // Domain Socket for you, so you can remove the usual call to app.listen.

--- a/lambdas/static-asset-uploader/index.js
+++ b/lambdas/static-asset-uploader/index.js
@@ -188,7 +188,8 @@ function addConfigFile(bucketName, event) {
             identityPoolId: event.ResourceProperties.IdentityPoolId,
             userPoolId: event.ResourceProperties.UserPoolId,
             userPoolClientId: event.ResourceProperties.UserPoolClientId,
-            userPoolDomain: event.ResourceProperties.UserPoolDomain
+            userPoolDomain: event.ResourceProperties.UserPoolDomain,
+            feedbackEnabled: event.ResourceProperties.FeedbackEnabled
         },
         params = {
             Bucket: bucketName,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the ability for the customers of dev portal owners to provide feedback. Feedback is submitted through a form, stored in a new table in DynamoDB, and the owner is notified via email by subscribing to a new SNS topic. There are 4 commits in this PR:
 - __4d96ae5__
   - Adds an optional parameter `DevPortalAdminEmail` to the CloudFormation stack which, if provided, creates a DynamoDB table to store customer feedback, an SNS topic to receive email notifications when feedback is submitted, and the necessary permissions and variables to let the frontend do its thing.
 - __d880e5d__
   - Ensures that a boolean `feedbackEnabled` is written to `config.js` denoting whether or not the dev portal owner has opted into customer feedback by providing their email address
 - __a6e340f__
   - Adds express handlers to interact with DynamoDB and SNS
 - __9c05deb__
   - Adds the form on the front end
 - __805455b__
   - Adds unit tests and some minor refactoring
 - __e2003c9__
   - Slight refactoring
 - __9d5a57b__
   - Swap out `Fn::If` for `!If`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
