### PR TITLE
Add admin API for showing & hiding SDK generation

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -631,6 +631,7 @@ Resources:
           - Effect: Allow
             Action:
             - s3:GetObject
+            - s3:PutObject
             Resource: !Join
               - ''
               - - 'arn:aws:s3:::'
@@ -668,6 +669,10 @@ Resources:
                 - :table/
                 - !Ref CustomersTable
                 - /index/MarketplaceCustomerIdIndex
+          - Effect: Allow
+            Action:
+            - lambda:InvokeFunction
+            Resource: !GetAtt CatalogUpdaterLambdaFunction.Arn
           - !If
             - EnableFeedbackSubmission
             - Effect: Allow
@@ -937,6 +942,7 @@ Resources:
           WEBSITE_BUCKET_NAME: !Ref DevPortalSiteS3BucketName
           StaticBucketName: !Ref ArtifactsS3BucketName
           CustomersTableName: !Ref DevPortalCustomersTableName
+          CatalogUpdaterFunctionArn: !GetAtt CatalogUpdaterLambdaFunction.Arn
           FeedbackTableName: !Ref DevPortalFeedbackTableName
           FeedbackSnsTopicArn:
             !If [EnableFeedbackSubmission, !Ref FeedbackSubmittedSNSTopic, '']

--- a/dev-portal/src/services/api.js
+++ b/dev-portal/src/services/api.js
@@ -21,6 +21,8 @@ export function initApiGatewayClient({ accessKeyId, secretAccessKey, sessionToke
     sessionToken: sessionToken,
     region: awsRegion
   })
+
+  window.apigw = cachedClient
 }
 
 export function apiGatewayClient() {

--- a/lambdas/backend/__tests__/admin-catalog-visibility-test.js
+++ b/lambdas/backend/__tests__/admin-catalog-visibility-test.js
@@ -4,7 +4,6 @@ const deleteAdminCatalogVisibility = require('../express-route-handlers').delete
 const s3 = require('../express-route-handlers').s3
 const apigateway = require('../express-route-handlers').apigateway
 const promiser = require('../../setup-jest').promiser
-const routeHandlers = require('../../setup-jest')
 let catalog = require('../catalog/index')
 
 const mockResponseObject = {

--- a/lambdas/backend/__tests__/admin-sdk-generation-test.js
+++ b/lambdas/backend/__tests__/admin-sdk-generation-test.js
@@ -1,0 +1,173 @@
+const putAdminCatalogSdkGeneration = require('../express-route-handlers').putAdminCatalogSdkGeneration
+const deleteAdminCatalogSdkGeneration = require('../express-route-handlers').deleteAdminCatalogSdkGeneration
+const handlers = require('../express-route-handlers')
+const s3 = require('../express-route-handlers').s3
+const lambda = require('../express-route-handlers').lambda
+const promiser = require('../../setup-jest').promiser
+const generateResponseContext = require('../../setup-jest').generateResponseContext
+const generateRequestContext = require('../../setup-jest').generateRequestContext
+
+describe('putAdminCatalogSdkGeneration', () => {
+    test('it should call idempotentSdkGenerationUpdate', async () => {
+        let req = generateRequestContext()
+        req.params = { id: 'apiid_stagename' }
+
+        let mockedIdempotentSdkGenerationUpdate =
+            jest.spyOn(handlers, 'idempotentSdkGenerationUpdate')
+                .mockImplementation(() => {})
+
+        await handlers.putAdminCatalogSdkGeneration(req, {})
+
+        expect(handlers.idempotentSdkGenerationUpdate).toHaveBeenCalledTimes(1)
+        expect(handlers.idempotentSdkGenerationUpdate).toHaveBeenCalledWith(true, 'apiid_stagename', {})
+
+        mockedIdempotentSdkGenerationUpdate.mockReset()
+        mockedIdempotentSdkGenerationUpdate.mockRestore()
+    })
+})
+
+describe('deleteAdminCatalogSdkGeneration', () => {
+    test('it should call idempotentSdkGenerationUpdate', async () => {
+        let req = generateRequestContext()
+        req.params = {id: 'apiid_stagename'}
+
+        let mockedIdempotentSdkGenerationUpdate =
+            jest.spyOn(handlers, 'idempotentSdkGenerationUpdate')
+                .mockImplementation(() => {})
+
+        await handlers.deleteAdminCatalogSdkGeneration(req, {})
+
+        expect(handlers.idempotentSdkGenerationUpdate).toHaveBeenCalledTimes(1)
+        expect(handlers.idempotentSdkGenerationUpdate).toHaveBeenCalledWith(false, 'apiid_stagename', {})
+
+        mockedIdempotentSdkGenerationUpdate.mockReset()
+        mockedIdempotentSdkGenerationUpdate.mockRestore()
+    })
+})
+
+describe('idempotentSdkGenerationUpdate', () => {
+    beforeEach(() => {
+        jest.resetAllMocks()
+    })
+
+    test('it should update sdkGeneration.json', async () => {
+        let res = generateResponseContext(),
+            body = JSON.stringify({
+                'apiid_stagename': false,
+                'otherapiid_otherstagename': false
+            })
+
+        s3.getObject = jest.fn().mockReturnValue(promiser({
+            Body: body
+        }))
+        s3.upload = jest.fn().mockReturnValue(promiser())
+        lambda.invoke = jest.fn().mockReturnValue(promiser())
+
+        process.env.StaticBucketName = 'staticBucketName'
+        process.env.CatalogUpdaterFunctionArn = 'somebigfunctionarn'
+
+
+        await handlers.idempotentSdkGenerationUpdate(true, 'apiid_stagename', res)
+
+        expect(s3.getObject).toHaveBeenCalledTimes(1)
+        expect(s3.getObject).toHaveBeenCalledWith({
+            Bucket: 'staticBucketName',
+            Key: 'sdkGeneration.json'
+        })
+
+        expect(s3.upload).toHaveBeenCalledTimes(1)
+        expect(s3.upload).toHaveBeenCalledWith({
+            Bucket: 'staticBucketName',
+            Key: 'sdkGeneration.json',
+            Body: JSON.stringify({
+                'apiid_stagename': true,
+                'otherapiid_otherstagename': false
+            })
+        })
+
+        expect(lambda.invoke).toHaveBeenCalledTimes(1)
+        expect(lambda.invoke).toHaveBeenCalledWith({
+            FunctionName: 'somebigfunctionarn',
+            InvocationType: 'RequestResponse',
+            LogType: 'None'
+        })
+
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.status().json).toHaveBeenCalledWith({ message: 'Success' })
+    })
+
+    test('it should update sdkGeneration.json even when the api is not yet in the file', async () => {
+        let res = generateResponseContext(),
+        body = JSON.stringify({
+            'otherapiid_otherstagename': false
+        })
+
+        s3.getObject = jest.fn().mockReturnValue(promiser({
+            Body: body
+        }))
+        s3.upload = jest.fn().mockReturnValue(promiser())
+        lambda.invoke = jest.fn().mockReturnValue(promiser())
+
+        process.env.StaticBucketName = 'staticBucketName'
+        process.env.CatalogUpdaterFunctionArn = 'somebigfunctionarn'
+
+        await handlers.idempotentSdkGenerationUpdate(true, 'apiid_stagename', res)
+
+        expect(s3.getObject).toHaveBeenCalledTimes(1)
+        expect(s3.getObject).toHaveBeenCalledWith({
+            Bucket: 'staticBucketName',
+            Key: 'sdkGeneration.json'
+        })
+
+        expect(s3.upload).toHaveBeenCalledTimes(1)
+        expect(s3.upload).toHaveBeenCalledWith({
+            Bucket: 'staticBucketName',
+            Key: 'sdkGeneration.json',
+            Body: JSON.stringify({
+                'otherapiid_otherstagename': false,
+                'apiid_stagename': true
+            })
+        })
+
+        expect(lambda.invoke).toHaveBeenCalledTimes(1)
+        expect(lambda.invoke).toHaveBeenCalledWith({
+            FunctionName: 'somebigfunctionarn',
+            InvocationType: 'RequestResponse',
+            LogType: 'None'
+        })
+
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.status().json).toHaveBeenCalledWith({ message: 'Success' })
+    })
+
+    test('it should not update sdkGeneration.json when it\'s unnecessary', async () => {
+        let res = generateResponseContext(),
+        body = JSON.stringify({
+            'apiid_stagename': false,
+            'otherapiid_otherstagename': false
+        })
+
+        s3.getObject = jest.fn().mockReturnValue(promiser({
+            Body: body
+        }))
+        s3.upload = jest.fn().mockReturnValue(promiser())
+        lambda.invoke = jest.fn().mockReturnValue(promiser())
+
+        process.env.StaticBucketName = 'staticBucketName'
+        process.env.CatalogUpdaterFunctionArn = 'somebigfunctionarn'
+
+        await handlers.idempotentSdkGenerationUpdate(false, 'apiid_stagename', res)
+
+        expect(s3.getObject).toHaveBeenCalledTimes(1)
+        expect(s3.getObject).toHaveBeenCalledWith({
+            Bucket: 'staticBucketName',
+            Key: 'sdkGeneration.json'
+        })
+
+        expect(s3.upload).toHaveBeenCalledTimes(0)
+        expect(lambda.invoke).toHaveBeenCalledTimes(0)
+
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.status().json).toHaveBeenCalledWith({ message: 'Success' })
+    })
+})

--- a/lambdas/backend/express-route-handlers.js
+++ b/lambdas/backend/express-route-handlers.js
@@ -439,22 +439,22 @@ async function idempotentSdkGenerationUpdate(parity, id, res) {
             LogType: 'None'
         }).promise()
 
-        res.status(200).json({message: 'Success'})
+        res.status(200).json({ message: 'Success' })
     } else {
-        res.status(200).json({message: 'Success'})
+        res.status(200).json({ message: 'Success' })
     }
 }
 
 async function putAdminCatalogSdkGeneration(req, res) {
     console.log(`PUT /admin/catalog/${req.params.id}/sdkGeneration for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
 
-    await idempotentSdkGenerationUpdate(true, req.params.id, res)
+    await exports.idempotentSdkGenerationUpdate(true, req.params.id, res)
 }
 
 async function deleteAdminCatalogSdkGeneration(req, res) {
     console.log(`DELETE /admin/catalog/${req.params.id}/sdkGeneration for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
 
-    await idempotentSdkGenerationUpdate(false, req.params.id, res)
+    await exports.idempotentSdkGenerationUpdate(false, req.params.id, res)
 }
 
 exports = module.exports = {
@@ -474,6 +474,7 @@ exports = module.exports = {
     deleteAdminCatalogVisibility,
     putAdminCatalogSdkGeneration,
     deleteAdminCatalogSdkGeneration,
+    idempotentSdkGenerationUpdate,
     s3: new AWS.S3(),
     apigateway: new AWS.APIGateway(),
     lambda: new AWS.Lambda()

--- a/lambdas/backend/express-server.js
+++ b/lambdas/backend/express-server.js
@@ -34,6 +34,8 @@ app.post('/feedback', handlers.postFeedback)
 app.get('/admin/catalog/visibility', handlers.getAdminCatalogVisibility)
 app.post('/admin/catalog/visibility', handlers.postAdminCatalogVisibility)
 app.delete('/admin/catalog/visibility', handlers.deleteAdminCatalogVisibility)
+app.put('/admin/catalog/:id/sdkGeneration', handlers.putAdminCatalogSdkGeneration)
+app.delete('/admin/catalog/:id/sdkGeneration', handlers.deleteAdminCatalogSdkGeneration)
 
 // The aws-serverless-express library creates a server and listens on a Unix
 // Domain Socket for you, so you can remove the usual call to app.listen.

--- a/lambdas/catalog-updater/__tests__/catalog-updater-test.js
+++ b/lambdas/catalog-updater/__tests__/catalog-updater-test.js
@@ -154,26 +154,28 @@ describe('buildCatalog', () => {
                     apis: [{
                         swagger: 'prodSwaggerBody',
                         id: 'a1b2c3d4e5',
-                        stage: 'prod'
+                        stage: 'prod',
+                        sdkGeneration: false
                     }]
                 }],
                 generic: [{
                     swagger: 'genericSwaggerBody',
                     id: 'somehugehash',
-                    generic: true
+                    generic: true,
+                    sdkGeneration: false
                 }]
             }
 
         index.gateway.getUsagePlans = jest.fn().mockReturnValueOnce(promiser({ items: [usagePlan] }))
 
-        expect(await index.buildCatalog(swaggerFileReprs)).toEqual(expectedCatalog)
+        expect(await index.buildCatalog(swaggerFileReprs, {})).toEqual(expectedCatalog)
     })
 })
 
 describe('usagePlanToCatalogObject', () => {
 
-    let firstValidApi = { swagger: 'prodSwaggerBody', id: 'a1b2c3d4e5', stage: 'prod' }
-    let secondValidApi = { swagger: 'gammaSwaggerBody', id: 'a1b2c3d4e5', stage: 'gamma' }
+    let firstValidApi = { swagger: 'prodSwaggerBody', id: 'a1b2c3d4e5', stage: 'prod', sdkGeneration: false }
+    let secondValidApi = { swagger: 'gammaSwaggerBody', id: 'a1b2c3d4e5', stage: 'gamma', sdkGeneration: false }
 
     let usagePlan = {
         id: 'MYID',
@@ -194,7 +196,7 @@ describe('usagePlanToCatalogObject', () => {
             { body: 'genericSwaggerBody', generic: true, id: 'somehugehash' } // NOT included in usage plans (generic)
         ]
 
-        const catalogObject = index.usagePlanToCatalogObject(usagePlan, swaggerFileReprs)
+        const catalogObject = index.usagePlanToCatalogObject(usagePlan, swaggerFileReprs, {})
 
         expect(catalogObject.apis.length).toEqual(2)
         expect(catalogObject.apis[0]).toEqual(firstValidApi)
@@ -206,7 +208,7 @@ describe('usagePlanToCatalogObject', () => {
             { body: 'genericSwaggerBody', generic: true, id: 'somehugehash' } // NOT included in usage plans (generic)
         ]
 
-        const catalogObject = index.usagePlanToCatalogObject(usagePlan, swaggerFileReprs)
+        const catalogObject = index.usagePlanToCatalogObject(usagePlan, swaggerFileReprs, {})
 
         expect(catalogObject.apis.length).toEqual(0)
     })
@@ -214,7 +216,7 @@ describe('usagePlanToCatalogObject', () => {
     test('correctly handles empty swaggerFileReprs', async () => {
         const swaggerFileReprs = []
 
-        const catalogObject = index.usagePlanToCatalogObject(usagePlan, swaggerFileReprs)
+        const catalogObject = index.usagePlanToCatalogObject(usagePlan, swaggerFileReprs, {})
 
         expect(catalogObject.apis.length).toEqual(0)
     })
@@ -295,11 +297,15 @@ describe('copyAnyMethod', () => {
 })
 
 describe('handler', () => {
+    afterEach(() => {
+        delete process.env.BucketName;
+    })
+
     test('should fetch from S3 and upload to S3 when run', async () => {
         // this is a very abstract test
         // we just want to verify that we hand data around correctly
         // so, string tokens used in place of actual data
-        let mockEvent = { Records: [{ s3: { bucket: { name: 'bucketName' } } }] },
+        let mockEvent = {},
             expectedUploadParams = {
                 Bucket: 'bucketName',
                 Key: 'catalog.json',
@@ -307,6 +313,12 @@ describe('handler', () => {
                 Body: '"catalog"'
             }
 
+        process.env.BucketName = 'bucketName'
+
+        // this is the contents of the file sdkGeneration.json in S3
+        index.s3.getObject =
+            jest.fn().mockReturnValue(promiser({ Body: new Buffer('{ "apiid_stagename": true }') }))
+        // these are all the files in the catalog/ directory of the S3 bucket
         index.s3.listObjectsV2 =
             jest.fn(() => true).mockReturnValue(promiser({ Contents: ['listedObjects'] }))
         index.swaggerFileFilter =
@@ -320,6 +332,8 @@ describe('handler', () => {
 
         await index.handler(mockEvent, {})
 
+        expect(index.s3.getObject).toBeCalledTimes(1)
+        expect(index.s3.getObject).toBeCalledWith({ Bucket: 'bucketName', Key: 'sdkGeneration.json' })
         expect(index.s3.listObjectsV2).toBeCalledTimes(1)
         expect(index.s3.listObjectsV2).toBeCalledWith({ Bucket: 'bucketName' })
         expect(index.swaggerFileFilter).toBeCalledTimes(1)
@@ -327,8 +341,8 @@ describe('handler', () => {
         expect(index.getSwaggerFile).toBeCalledTimes(1)
         expect(index.getSwaggerFile).toBeCalledWith('listedObjects', expect.anything(), expect.anything())
         expect(index.buildCatalog).toBeCalledTimes(1)
-        expect(index.buildCatalog).toBeCalledWith(['swagger'])
+        expect(index.buildCatalog).toBeCalledWith(['swagger'], { 'apiid_stagename': true })
         expect(index.s3.upload).toBeCalledTimes(1)
-        expect(index.s3.upload).toBeCalledWith(expectedUploadParams, expect.any(Object))
+        expect(index.s3.upload).toBeCalledWith(expectedUploadParams)
     })
 })

--- a/lambdas/catalog-updater/__tests__/catalog-updater-test.js
+++ b/lambdas/catalog-updater/__tests__/catalog-updater-test.js
@@ -317,7 +317,7 @@ describe('handler', () => {
 
         // this is the contents of the file sdkGeneration.json in S3
         index.s3.getObject =
-            jest.fn().mockReturnValue(promiser({ Body: new Buffer.from('{ "apiid_stagename": true }') }))
+            jest.fn().mockReturnValue(promiser({ Body: Buffer.from('{ "apiid_stagename": true }') }))
         // these are all the files in the catalog/ directory of the S3 bucket
         index.s3.listObjectsV2 =
             jest.fn(() => true).mockReturnValue(promiser({ Contents: ['listedObjects'] }))

--- a/lambdas/catalog-updater/__tests__/catalog-updater-test.js
+++ b/lambdas/catalog-updater/__tests__/catalog-updater-test.js
@@ -317,7 +317,7 @@ describe('handler', () => {
 
         // this is the contents of the file sdkGeneration.json in S3
         index.s3.getObject =
-            jest.fn().mockReturnValue(promiser({ Body: new Buffer('{ "apiid_stagename": true }') }))
+            jest.fn().mockReturnValue(promiser({ Body: new Buffer.from('{ "apiid_stagename": true }') }))
         // these are all the files in the catalog/ directory of the S3 bucket
         index.s3.listObjectsV2 =
             jest.fn(() => true).mockReturnValue(promiser({ Contents: ['listedObjects'] }))

--- a/lambdas/setup-jest.js
+++ b/lambdas/setup-jest.js
@@ -36,7 +36,31 @@ function promiser(mockResolveValue, mockRejectedValue) {
     }
 }
 
+function generateResponseContext() {
+    return {
+        status: jest.fn().mockReturnValue({
+            json: jest.fn()
+        })
+    }
+}
+
+function generateRequestContext() {
+    return {
+        apiGateway: {
+            event: {
+                requestContext: {
+                    identity: {
+                        cognitoIdentityId: 'qwertyuiop'
+                    }
+                }
+            }
+        }
+    }
+}
+
 // export helpers
 exports = module.exports = {
-    promiser
+    promiser,
+    generateRequestContext,
+    generateResponseContext
 }

--- a/lambdas/setup-jest.js
+++ b/lambdas/setup-jest.js
@@ -1,5 +1,6 @@
 // jest setup
 global.console.log = jest.fn()
+global.console.dir = jest.fn()
 
 
 // helpers


### PR DESCRIPTION
This adds two new admin API endpoints (/admin/catalog/:id/sdkGeneration).

Additionally, it adds a new file, sdkGeneration.json, in S3 that stores
whether given api-stages or generic apis are enabled for sdk generation.

sdkGeneration.json is read by catalogUpdater to generate the catalog.
The new sdkGeneration endpoints invoke the catalogUpdater lambda function
to cause a fresh catalog to be generated each time an API is enabled or
disabled for catalog generation.

Other changes include updating staticAssetUploader to create an empty
sdkGeneration.json file, fixing tests broken by these changes, and
refactoring catalogUpdater to an async/await style.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
