### PR TITLE
Get sdk

### DIFF
--- a/dev-portal/public/apigateway-js-sdk/apigClient.js
+++ b/dev-portal/public/apigateway-js-sdk/apigClient.js
@@ -110,7 +110,7 @@ apigClientFactory.newClient = function (config) {
             verb: 'GET',
             path: pathComponent + path,
             headers: apiGateway.core.utils.parseParametersToObject(params, []),
-            queryParams: apiGateway.core.utils.parseParametersToObject(params, ['start', 'end']),
+            queryParams: apiGateway.core.utils.parseParametersToObject(params, ['start', 'end', 'sdkType', 'parameters']),
             body: body
         };
 

--- a/lambdas/backend/__tests__/get-sdk-test.js
+++ b/lambdas/backend/__tests__/get-sdk-test.js
@@ -1,0 +1,127 @@
+const handlers = require('../express-route-handlers')
+const apigateway = require('../express-route-handlers').apigateway
+const promiser = require('../../setup-jest').promiser
+const generateResponseContext = require('../../setup-jest').generateResponseContext
+const generateRequestContext = require('../../setup-jest').generateRequestContext
+
+let catalog = require('../catalog/index')
+
+jest.mock('../catalog/index')
+
+describe('getSdk', () => {
+    test('it should return a generated SDK, proxying through params', async () => {
+        let req = generateRequestContext(),
+            res = generateResponseContext()
+
+        req.params = { id: 'apiId_stageName' }
+        req.query = {}
+        req.query = { sdkType: 'ruby', parameters: { serviceName: 'my-new-ruby-service' } }
+
+        apigateway.getSdk = jest.fn().mockReturnValue(promiser({
+            body: Buffer.from('returnedSDK')
+        }))
+
+        catalog.mockReturnValue({
+            apiGateway: [
+                {
+                    apis: [
+                        {
+                            id: 'apiId',
+                            stage: 'stageName',
+                            sdkGeneration: true
+                        }
+                    ]
+                }
+            ]
+        })
+
+        await handlers.getSdk(req, res)
+
+        expect(catalog).toHaveBeenCalledTimes(1)
+
+        expect(apigateway.getSdk).toHaveBeenCalledTimes(1)
+        expect(apigateway.getSdk).toHaveBeenCalledWith({
+            restApiId: 'apiId',
+            sdkType: 'ruby',
+            stageName: 'stageName',
+            parameters: { serviceName: 'my-new-ruby-service' }
+        })
+
+        expect(res.attachment).toHaveBeenCalledTimes(1)
+        expect(res.attachment().send).toHaveBeenCalledTimes(1)
+        expect(res.attachment().send).toHaveBeenCalledWith(Buffer.from('returnedSDK'))
+    })
+
+    test('it should not return SDKs for APIs not in the catalog', async () => {
+        let req = generateRequestContext(),
+            res = generateResponseContext()
+
+        req.params = { id: 'anApi_notInTheCatalog' }
+        req.query = { sdkType: 'ruby', parameters: { serviceName: 'my-new-ruby-service' } }
+
+        catalog.mockReturnValue({
+            apiGateway: [
+                {
+                    apis: [
+                        {
+                            id: 'apiId',
+                            stage: 'stageName',
+                            sdkGeneration: true
+                        }
+                    ]
+                }
+            ]
+        })
+
+        await handlers.getSdk(req, res)
+
+        expect(catalog).toHaveBeenCalledTimes(1)
+
+        expect(apigateway.getSdk).toHaveBeenCalledTimes(0)
+
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.status().json).toHaveBeenCalledTimes(1)
+        expect(res.status().json).toHaveBeenCalledWith({ message: `API with ID (anApi) and Stage (notInTheCatalog) could not be found.` })
+    })
+
+    test('it should not return SDKs for APIs in the catalog but with SDK generation disabled', async () => {
+        let req = generateRequestContext(),
+            res = generateResponseContext()
+
+        req.params = { id: 'thisApi_shouldNotGenerateSDKs' }
+        req.query = {}
+        req.query.sdkType = 'whitespace'
+        req.query = { sdkType: 'ruby', parameters: { serviceName: 'my-new-ruby-service' } }
+
+        catalog.mockReturnValue({
+            apiGateway: [
+                {
+                    apis: [
+                        {
+                            id: 'apiId',
+                            stage: 'stageName',
+                            sdkGeneration: true
+                        },
+                        {
+                            id: 'thisApi',
+                            stage: 'shouldNotGenerateSDKs',
+                            sdkGeneration: false
+                        }
+                    ]
+                }
+            ]
+        })
+
+        await handlers.getSdk(req, res)
+
+        expect(catalog).toHaveBeenCalledTimes(1)
+
+        expect(apigateway.getSdk).toHaveBeenCalledTimes(0)
+
+        expect(res.status).toHaveBeenCalledTimes(1)
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.status().json).toHaveBeenCalledTimes(1)
+        expect(res.status().json).toHaveBeenCalledWith({ message: `API with ID (thisApi) and Stage (shouldNotGenerateSDKs) is not enabled for SDK generation.` })
+    })
+})

--- a/lambdas/backend/express-route-handlers.js
+++ b/lambdas/backend/express-route-handlers.js
@@ -20,8 +20,8 @@ function getUsagePlanFromCatalog(usagePlanId) {
 }
 
 function postSignIn(req, res) {
-    console.log(`POST /signin for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
     const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`POST /signin for Cognito ID: ${cognitoIdentityId}`)
 
     function errFunc(data) {
         console.log(`error: ${data}`)
@@ -56,15 +56,15 @@ function postSignIn(req, res) {
 }
 
 function getCatalog(req, res) {
-    console.log(`GET /catalog for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`GET /catalog for Cognito ID: ${getCognitoIdentityId(req)}`)
     catalog()
         .then(catalog => res.status(200).json(catalog))
         .catch(error => res.status(error.statusCode).json(error))
 }
 
 function getApiKey(req, res) {
-    console.log(`GET /apikey for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
     const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`GET /apikey for Cognito ID: ${cognitoIdentityId}`)
 
     function errFunc(data) {
         console.log(`error: ${data}`)
@@ -86,21 +86,22 @@ function getApiKey(req, res) {
 }
 
 function getSubscriptions(req, res) {
-    console.log(`GET /subscriptions for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    let cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`GET /subscriptions for Cognito ID: ${cognitoIdentityId}`)
 
     function errFunc(data) {
         console.log(`error: ${data}`)
         res.status(500).json(data)
     }
 
-    customersController.getUsagePlansForCustomer(req.apiGateway.event.requestContext.identity.cognitoIdentityId, errFunc, (data) => {
+    customersController.getUsagePlansForCustomer(cognitoIdentityId, errFunc, (data) => {
         res.status(200).json(data.items)
     })
 }
 
 function putSubscription(req, res) {
-    console.log(`PUT /subscriptions for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
     const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`PUT /subscriptions for Cognito ID: ${cognitoIdentityId}`)
     const usagePlanId = req.params.usagePlanId
 
     getUsagePlanFromCatalog(usagePlanId).then((usagePlan) => {
@@ -124,8 +125,8 @@ function putSubscription(req, res) {
 }
 
 function getUsage(req, res) {
-    console.log(`GET /usage for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
     const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`GET /usage for Cognito ID: ${cognitoIdentityId}`)
     const usagePlanId = req.params.usagePlanId
 
     function errFunc(data) {
@@ -166,8 +167,8 @@ function getUsage(req, res) {
 }
 
 function deleteSubscription(req, res) {
-    console.log(`DELETE /subscriptions for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
     const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`DELETE /subscriptions for Cognito ID: ${cognitoIdentityId}`)
     const usagePlanId = req.params.usagePlanId
 
     function error(data) {
@@ -191,7 +192,7 @@ function deleteSubscription(req, res) {
 }
 
 function postMarketplaceConfirm(req, res) {
-    console.log(`POST /marketplace-confirm for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`POST /marketplace-confirm for Cognito ID: ${getCognitoIdentityId(req)}`)
     // no auth
     // this is the redirect URL for AWS Marketplace products
     // i.e. https://YOUR_API_GATEWAY_API_ID.execute-api.us-east-1.amazonaws.com/prod/marketplace-confirm/[USAGE_PLAN_ID]
@@ -217,11 +218,12 @@ function postMarketplaceConfirm(req, res) {
 }
 
 function putMarketplaceSubscription(req, res) {
-    console.log(`PUT /marketplace-subscriptions/:usagePlanId for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`PUT /marketplace-subscriptions/:usagePlanId for Cognito ID: ${cognitoIdentityId}`)
+
     const marketplaceToken = req.body.token
     const usagePlanId = req.params.usagePlanId
     console.log(`Marketplace token: ${marketplaceToken} usage plan id: ${usagePlanId}`)
-    const cognitoIdentityId = getCognitoIdentityId(req)
     console.log(`cognito id: ${cognitoIdentityId}`)
 
     function error(data) {
@@ -260,7 +262,8 @@ function putMarketplaceSubscription(req, res) {
 }
 
 function getFeedback(req, res) {
-    console.log(`GET /feedback for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`GET /feedback for Cognito ID: ${getCognitoIdentityId(req)}`)
+
     if (!feedbackEnabled) {
         res.status(401).json("Customer feedback not enabled")
     } else {
@@ -276,8 +279,8 @@ function getFeedback(req, res) {
 }
 
 function postFeedback(req, res) {
-    console.log(`POST /feedback for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
     const cognitoIdentityId = getCognitoIdentityId(req)
+    console.log(`POST /feedback for Cognito ID: ${cognitoIdentityId}`)
 
     if (!feedbackEnabled) {
         res.status(401).json("Customer feedback not enabled")
@@ -289,7 +292,7 @@ function postFeedback(req, res) {
 }
 
 async function getAdminCatalogVisibility(req, res) {
-    console.log(`GET /admin/catalog/visibility for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`GET /admin/catalog/visibility for Cognito ID: ${getCognitoIdentityId(req)}`)
     try {
 
         let visibility = { apiGateway: [] }, catalogObject = await catalog(),
@@ -341,7 +344,7 @@ async function getAdminCatalogVisibility(req, res) {
 }
 
 async function postAdminCatalogVisibility(req, res) {
-    console.log(`POST /admin-catalog-visibility for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`POST /admin-catalog-visibility for Cognito ID: ${getCognitoIdentityId(req)}`)
     // for apigateway managed APIs, provide "apiId_stageName"
     // in the apiKey field
     if(req.body && req.body.apiKey) {
@@ -383,7 +386,7 @@ async function postAdminCatalogVisibility(req, res) {
 }
 
 async function deleteAdminCatalogVisibility(req, res) {
-    console.log(`DELETE /admin/catalog/visibility for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`DELETE /admin/catalog/visibility for Cognito ID: ${getCognitoIdentityId(req)}`)
     // for apigateway managed APIs, provide "apiId_stageName"
     // in the apiKey field
     if(req.body && req.body.apiKey) {
@@ -461,13 +464,13 @@ async function idempotentSdkGenerationUpdate(parity, id, res) {
 }
 
 async function putAdminCatalogSdkGeneration(req, res) {
-    console.log(`PUT /admin/catalog/${req.params.id}/sdkGeneration for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`PUT /admin/catalog/${req.params.id}/sdkGeneration for Cognito ID: ${getCognitoIdentityId(req)}`)
 
     await exports.idempotentSdkGenerationUpdate(true, req.params.id, res)
 }
 
 async function deleteAdminCatalogSdkGeneration(req, res) {
-    console.log(`DELETE /admin/catalog/${req.params.id}/sdkGeneration for Cognito ID: ${req.apiGateway.event.requestContext.identity.cognitoIdentityId}`)
+    console.log(`DELETE /admin/catalog/${req.params.id}/sdkGeneration for Cognito ID: ${getCognitoIdentityId(req)}`)
 
     await exports.idempotentSdkGenerationUpdate(false, req.params.id, res)
 }

--- a/lambdas/backend/express-server.js
+++ b/lambdas/backend/express-server.js
@@ -28,6 +28,7 @@ app.post('/marketplace-confirm/:usagePlanId', handlers.postMarketplaceConfirm)
 app.put('/marketplace-subscriptions/:usagePlanId', handlers.putMarketplaceSubscription)
 app.get('/feedback', handlers.getFeedback)
 app.post('/feedback', handlers.postFeedback)
+app.get('/catalog/:id/sdk', handlers.getSdk)
 
 
 // admin APIs

--- a/lambdas/setup-jest.js
+++ b/lambdas/setup-jest.js
@@ -41,6 +41,9 @@ function generateResponseContext() {
     return {
         status: jest.fn().mockReturnValue({
             json: jest.fn()
+        }),
+        attachment: jest.fn().mockReturnValue({
+            send: jest.fn()
         })
     }
 }


### PR DESCRIPTION
*Description of changes:*
Adds the non-admin get SDK endpoint, which generates an SDK for the user. Commit by commit view will be best.

The change to the generated SDK is sort of a hack, and I want to rewrite apiGateway.core.utils.parseParametersToObject in the future to silently proxy all query params instead of only proxying enumerated ones, and always including the enumerated (even when undefined). Yuck.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
