### PR TITLE
Fix test running on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "node"
+  # we can't use latest because 11.11 breaks jest's env variable mock
+  - "11.10.1"
 
 cache: npm
 


### PR DESCRIPTION
*Description of changes:*
So, node v11.11 broke Jest's process.env mocks, as documented here:
https://github.com/facebook/jest/issues/8069

While Jest already has a fix out, CRA hasn't consumed that fix, and has
large, unfriendly warning text about running tests inside CRA using a
higher version of jest than CRA ships with. To get around this, we're
fixing the node version on Travis to v11.10 temporarily, and will
remove that limitation when CRA has consumed Jest's fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
