### PR TITLE
Fix IAD S3 bug

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -115,6 +115,7 @@ Conditions:
   NoCustomDomainName: !Not [ !Condition UseCustomDomainName ]
   UseRoute53: !And [!Equals [!Ref UseRoute53Nameservers, 'true'], !Condition UseCustomDomainName]
   EnableFeedbackSubmission: !Not [!Equals [!Ref DevPortalAdminEmail, '']]
+  InUSEastOne: !Equals [!Ref 'AWS::Region', 'us-east-1']
 
 Resources:
   ApiGatewayApi:
@@ -1312,7 +1313,9 @@ Resources:
         Comment: !Sub '${AWS::StackName} distribution'
         Origins:
           - Id: 'dev-portal-site-s3-bucket'
-            DomainName: !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3-', !Ref 'AWS::Region', '.amazonaws.com']]
+            DomainName: !If ['InUSEastOne',
+              !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3.amazonaws.com']],
+              !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3-', !Ref 'AWS::Region', '.amazonaws.com']]]
             S3OriginConfig:
              OriginAccessIdentity: !Sub >-
                origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}
@@ -1339,7 +1342,9 @@ Resources:
         Comment: !Sub '${AWS::StackName} distribution'
         Origins:
           - Id: 'dev-portal-site-s3-bucket'
-            DomainName: !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3-', !Ref 'AWS::Region', '.amazonaws.com']]
+            DomainName: !If ['InUSEastOne',
+              !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3.amazonaws.com']],
+              !Join ['', [!Ref DevPortalSiteS3BucketName, '.s3-', !Ref 'AWS::Region', '.amazonaws.com']]]
             S3OriginConfig:
              OriginAccessIdentity: !Sub >-
                origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}


### PR DESCRIPTION
*Description of changes:*
So, S3 has both regional and global endpoints. Regional endpoints look
like 'bucketName.s3-region.amazonaws.com', and the global endpoint looks
like 'bucketName.s3.amazonawas.com'. Earlier, I found out that the
global DNS takes ~40 minutes to propagate, and that time is not tracked
in CloudFormation, so CFN will declare the stack ready before the
CloudFront distribution points to a working origin.

To mitigate that, I moved the stack to using only the regional endpoints.
Unfortunately, us-east-1 never gets a regional DNS (!!!), so in us-east-1  we need
to always use the global endpoint. This change moves to that behavior;
global endpoint in us-east-1 , regional endpoint everywhere else.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
