### PR TITLE
Api keys

### DIFF
--- a/lambdas/backend/__tests__/customers-controller.js
+++ b/lambdas/backend/__tests__/customers-controller.js
@@ -1,0 +1,96 @@
+const customers = require('../_common/customers-controller')
+const promiser = require('../../setup-jest').promiser
+
+describe('customersController', () => {
+    test('ensureCustomerItem verifies that DDB is up-to-date', async () => {
+        let error = jest.fn(),
+            callback = jest.fn(),
+            entry = {
+                Id: 'cognitoIdentityId',
+                UserPoolId: 'cognitoUserId',
+                ApiKeyId: 'keyId'
+            }
+
+        customers.dynamoDb.get = jest.fn().mockReturnValue(promiser({ Item: entry }))
+
+        let returnValue = await customers.ensureCustomerItem('cognitoIdentityId', 'cognitoUserId', 'keyId', error, callback)
+
+        expect(customers.dynamoDb.get).toHaveBeenCalledTimes(1)
+        expect(customers.dynamoDb.get).toHaveBeenCalledWith({
+            TableName: 'DevPortalCustomers',
+            Key: {
+                Id: 'cognitoIdentityId'
+            }
+        })
+
+        expect(returnValue).toEqual(entry)
+    })
+
+    test('ensureCustomerItem fixes DDB if it is not up-to-date', async () => {
+        let error = jest.fn(),
+            callback = jest.fn(),
+            entry = {
+                Id: 'cognitoIdentityId',
+                UserPoolId: 'cognitoUserId',
+                ApiKeyId: 'keyId'
+            }
+
+        customers.dynamoDb.get = jest.fn().mockReturnValue(promiser({ Item: undefined }))
+
+        customers.dynamoDb.put = jest.fn().mockReturnValue(promiser({}))
+
+        let returnValue = await customers.ensureCustomerItem('cognitoIdentityId', 'cognitoUserId', 'keyId', error, callback)
+
+        expect(customers.dynamoDb.get).toHaveBeenCalledTimes(1)
+        expect(customers.dynamoDb.get).toHaveBeenCalledWith({
+            TableName: 'DevPortalCustomers',
+            Key: {
+                Id: 'cognitoIdentityId'
+            }
+        })
+
+        expect(customers.dynamoDb.put).toHaveBeenCalledTimes(1)
+        expect(customers.dynamoDb.put).toHaveBeenCalledWith({
+            TableName: 'DevPortalCustomers',
+            Item: entry
+        })
+
+        expect(returnValue).toEqual(entry)
+    })
+
+    test('ensureCustomerItem backfills UserPoolId', async () => {
+        let error = jest.fn(),
+            callback = jest.fn(),
+            oldEntry = {
+                Id: 'cognitoIdentityId',
+                ApiKeyId: 'keyId'
+            },
+            entry = {
+                Id: 'cognitoIdentityId',
+                UserPoolId: 'cognitoUserId',
+                ApiKeyId: 'keyId'
+            }
+
+        customers.dynamoDb.get = jest.fn().mockReturnValue(promiser({ Item: oldEntry }))
+
+        customers.dynamoDb.put = jest.fn().mockReturnValue(promiser({}))
+
+        let returnValue = await customers.ensureCustomerItem('cognitoIdentityId', 'cognitoUserId', 'keyId', error, callback)
+
+        expect(customers.dynamoDb.get).toHaveBeenCalledTimes(1)
+        expect(customers.dynamoDb.get).toHaveBeenCalledWith({
+            TableName: 'DevPortalCustomers',
+            Key: {
+                Id: 'cognitoIdentityId'
+            }
+        })
+
+        expect(customers.dynamoDb.put).toHaveBeenCalledTimes(1)
+        expect(customers.dynamoDb.put).toHaveBeenCalledWith({
+            TableName: 'DevPortalCustomers',
+            Item: entry
+        })
+
+        expect(returnValue).toEqual(entry)
+    })
+})

--- a/lambdas/jest.config.js
+++ b/lambdas/jest.config.js
@@ -21,13 +21,13 @@ module.exports = {
   // collectCoverage: false,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['*/*.{js,jsx}'],
+  collectCoverageFrom: ['**/*.{js,jsx}'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  coveragePathIgnorePatterns: [ '/node_modules/', 'express-server.js', 'express-server-local.js' ],
+  coveragePathIgnorePatterns: [ '/node_modules/', '/build/', 'express-server.js', 'express-server-local.js', 'setup-jest.js', 'jest.config.js', '/coverage/' ],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [


### PR DESCRIPTION
*Description of changes:*
Cognito has a core miss where user entries in an identity pool cannot
be linked to their corresponding user entry in a user pool. To work
around this, and to allow admins to correlate user entries, identity
entries, and api keys, we save all three to DDB.

This change also includes a refactor of several functions in
customersController to use a promise-y API, instead of a callback API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
