### PR TITLE
Add optional AWS SAM CLI profile option to be used to interact with A…

### DIFF
--- a/dev-portal/README.md
+++ b/dev-portal/README.md
@@ -30,6 +30,9 @@ module.exports = {
 
   // Set this to overwrite-content if you want to reset your custom content back to the defaults. Defaults to ``
   // staticAssetRebuildMode: `overwrite-content` // ONLY SET
+  
+  // AWS SAM CLI profile option: optional specific profile from your AWS credential file. Not used by default
+  //awsSamCliProfile: "my-profile"
 }
 ```
 4. Run `npm run release`. This will build the static assets, deploy them, and generate the `dev-portal/public/config.js` file needed for local development. Take note of the bucket names you use

--- a/dev-portal/scripts/deploy-stack.js
+++ b/dev-portal/scripts/deploy-stack.js
@@ -21,15 +21,19 @@ const customersTableName = deployerConfig.customersTableName || 'DevPortalCustom
 const cognitoDomainName = deployerConfig.cognitoDomainName || ''
 const staticAssetRebuildMode = deployerConfig.staticAssetRebuildMode || ''
 
+// AWS SAM CLI configuration
+const awsSamCliProfile = deployerConfig.awsSamCliProfile;
+const profileOption = awsSamCliProfile ? `--profile ${awsSamCliProfile}` : ''
+
 function main() {
   Promise.resolve()
-    .then(() => execute(`sam package --template-file ${samTemplate} --output-template-file ${packageConfig} --s3-bucket ${buildAssetsBucket}`, true))
-    .then(() => execute(`sam deploy --template-file ${packageConfig} --stack-name ${stackName} --capabilities CAPABILITY_NAMED_IAM --parameter-overrides StaticAssetRebuildToken="${Date.now()}" StaticAssetRebuildMode="${staticAssetRebuildMode}" DevPortalSiteS3BucketName="${siteAssetsBucket}" ArtifactsS3BucketName="${apiAssetsBucket}" DevPortalCustomersTableName="${customersTableName}" CognitoDomainNameOrPrefix="${cognitoDomainName}" --s3-bucket ${buildAssetsBucket}`, true))
-    .then(() => writeConfig(true))
-    .then(() => console.log('\n' + 'Process Complete! Run `npm run start` to launch run the dev portal locally.\n'.green()))
-    .catch(err => {
-      console.log(("" + err).red())
-    })
+      .then(() => execute(`sam package --template-file ${samTemplate} --output-template-file ${packageConfig} --s3-bucket ${buildAssetsBucket} ${profileOption}`, true))
+.then(() => execute(`sam deploy --template-file ${packageConfig} --stack-name ${stackName} --capabilities CAPABILITY_NAMED_IAM --parameter-overrides StaticAssetRebuildToken="${Date.now()}" StaticAssetRebuildMode="${staticAssetRebuildMode}" DevPortalSiteS3BucketName="${siteAssetsBucket}" ArtifactsS3BucketName="${apiAssetsBucket}" DevPortalCustomersTableName="${customersTableName}" CognitoDomainNameOrPrefix="${cognitoDomainName}" --s3-bucket ${buildAssetsBucket} ${profileOption}`, true))
+.then(() => writeConfig(true))
+.then(() => console.log('\n' + 'Process Complete! Run `npm run start` to launch run the dev portal locally.\n'.green()))
+.catch(err => {
+    console.log(("" + err).red())
+  })
 }
 
 if (samTemplate && packageConfig && stackName && buildAssetsBucket && siteAssetsBucket && apiAssetsBucket && customersTableName) {


### PR DESCRIPTION
Enable the optional use of the AWS SAM CLI profile option during the interactions with AWS API. 

*Issue #, if available:*
The implicit use of the default AWS CLI profile during the local development of the project.

*Description of changes:*
- Include the logic to retrieve the optional `awsSamCliProfile` parameter from the `deployer.config.js` file inside `/dev-portal/` folder and use it as option of the AWS SAM CLI (only when present) within the `./dev-portal/scripts/deploy-stack.js` file. 
- Describe the new available option in the README file of the UI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
