### PR TITLE
Add validation for boolean CloudFormation template parameters

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -108,11 +108,19 @@ Parameters:
     Type: String
     Description: Only applicable if creating a custom domain name for your dev portal. Defaults to false, and you'll need to provide your own nameserver hosting. If set to true, a Route53 HostedZone and RecordSet are created for you.
     Default: 'false'
+    AllowedValues: 
+      - 'false'
+      - 'true'
+    ConstraintDescription: Malformed input - Parameter UseRoute53Nameservers value must be either 'true' or 'false'
 
   DevelopmentMode:
     Type: String
     Description: Enabling this weakens security features (OAI, SSL, site S3 bucket with public read ACLs, Cognito callback verification, CORS, etc.) for easier development. Do not enable this in production! Additionally, do not update a stack that was previously in development mode to be a production stack; instead, make a new stack that has never been in development mode.
     Default: 'false'
+    AllowedValues: 
+      - 'false'
+      - 'true'
+    ConstraintDescription: Malformed input - Parameter DevelopmentMode value must be either 'true' or 'false'
 
 Conditions:
   UseCustomDomainName: !And [!And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]], !Condition NotDevelopmentMode]


### PR DESCRIPTION
*Issue #, if available:*
Issue #247 

*Description of changes:*
Added validation for the boolean parameters.
Only allows lowercase true or false.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
