### PR TITLE
Add validation for the rebuild mode CloudFormation template parameter

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -74,6 +74,10 @@ Parameters:
     Type: String
     Description: By default, a static asset rebuild doesn't overwrite custom-content. Provide the value `overwrite-content` to replace the custom-content with your local version. Don't do this unless you know what you're doing -- all custom changes in your s3 bucket will be lost. 
     Default: ''
+    AllowedValues:
+      - 'overwrite-content'
+      - ''
+    ConstraintDescription: Malformed input - Parameter StaticAssetRebuildMode value must be either 'overwrite-content' or left blank.
 
   MarketplaceSubscriptionTopicProductCode:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*
Issue #247

*Description of changes:*
Added validation for the StaticAssetRebuildMode parameter.
Only allows blank string or the value used by the lambda function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
