### PR TITLE
Add validation for cognito identity pool name CloudFormation template parameter

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -84,6 +84,9 @@ Parameters:
     Type: String
     Description: The name for your Cognito Identity Pool.
     Default: 'DevPortalIdentityPool'
+    MaxLength: 128
+    AllowedPattern: ^[a-zA-Z0-9+=,.@-]*$
+    ConstraintDescription: Malformed input - Parameter CognitoIdentityPoolName must Pool names must be between one and 128 characters long. They can contain uppercase and lowercase letters (a-z, A-Z), numbers (0-9), and the following special characters + = , . @ and -.
 
   CognitoDomainNameOrPrefix:
     Type: String

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -85,6 +85,7 @@ Parameters:
     Description: The name for your Cognito Identity Pool.
     Default: 'DevPortalIdentityPool'
     MaxLength: 128
+    MinLength: 1
     AllowedPattern: ^[a-zA-Z0-9+=,.@-]*$
     ConstraintDescription: Malformed input - Parameter CognitoIdentityPoolName must Pool names must be between one and 128 characters long. They can contain uppercase and lowercase letters (a-z, A-Z), numbers (0-9), and the following special characters + = , . @ and -.
 


### PR DESCRIPTION
*Issue #, if available:*
Issue #247
Also partially addresses item 1 from Issue #130

*Description of changes:*
Added validation for the cognito identity pool name parameter.
Validation uses the Min / Max length properties for length validation and regex for the name format validation.
From https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-name.html :
Pool names must be between one and 128 characters long. They can contain uppercase and lowercase letters (a-z, A-Z), numbers (0-9), and the following special characters + = , . @ and -

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
