### PR TITLE
Run `npm install` upon `npm run get-dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Serverless Developer Portal for API Gateway",
   "main": "lambda.js",
   "scripts": {
-    "get-dependencies": "npm run get-dev-portal-dependencies && npm run get-lambda-dependencies;",
+    "get-dependencies": "npm install && npm run get-dev-portal-dependencies && npm run get-lambda-dependencies;",
     "get-lambda-dependencies": "find lambdas/*/package.json -type f -exec sh -c 'cd $(dirname {}) && npm run get-dependencies' \\;",
     "get-dev-portal-dependencies": "(cd dev-portal; npm run get-dependencies)",
     "test": "node scripts/test.js",


### PR DESCRIPTION
When running `npm run get-dependencies`, I expect all dependencies to be installed so that I can build or test the package. However, because we previously did not run `npm install` as part of this command, some dependencies (such as xml-js) were missing. This PR resolves that issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
