### PR TITLE
Fetch all usage plan pages

### DIFF
--- a/lambdas/backend/express-route-handlers.js
+++ b/lambdas/backend/express-route-handlers.js
@@ -3,6 +3,7 @@ const feedbackController = require('./_common/feedback-controller.js')
 const AWS = require('aws-sdk')
 const catalog = require('./catalog/index')
 const hash = require('object-hash')
+const { getAllUsagePlans } = require('./shared/get-all-usage-plans')
 
 const Datauri = require('datauri')
 
@@ -421,7 +422,7 @@ async function getAdminCatalogVisibility(req, res) {
             })
         })
 
-        let usagePlans = await exports.apigateway.getUsagePlans().promise()
+        let usagePlans = await getAllUsagePlans(exports.apigateway)
 
         // In the case of apiGateway APIs, the client doesn't know if there are usage plan associated or not
         // so we need to provide that information. This can't be merged with the above loop:
@@ -431,7 +432,7 @@ async function getAdminCatalogVisibility(req, res) {
         visibility.apiGateway.map((apiEntry) => {
             apiEntry.subscribable = false
 
-            usagePlans.items.forEach((usagePlan) => {
+            usagePlans.forEach((usagePlan) => {
                 usagePlan.apiStages.forEach((apiStage) => {
                     if(apiEntry.id === apiStage.apiId && apiEntry.stage === apiStage.stage) {
                         apiEntry.subscribable = true

--- a/lambdas/backend/shared/get-all-usage-plans.js
+++ b/lambdas/backend/shared/get-all-usage-plans.js
@@ -1,0 +1,33 @@
+/**
+ * Fetches all usage plans, combining all pages into a single array.
+ *
+ * @param apiGateway
+ *    an instance of `AWS.APIGateway` to use for API calls
+ *
+ * @param paramOverrides
+ *    a parameter object passed in calls to `APIGateway.getUsagePlans`
+ *
+ * @returns
+ *    a Promise resolving with an array of items returned from
+ *    `APIGateway.getUsagePlans` calls
+ */
+async function getAllUsagePlans(apiGateway, paramOverrides = {}) {
+  // The maximum allowed value of `limit` is 500 according to
+  // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html#getUsagePlans-property
+  const defaultParams = {limit: 500, ...paramOverrides}
+
+  console.log('Fetching first page of usage plans')
+  let response = await apiGateway.getUsagePlans(defaultParams).promise()
+  const usagePlans = response.items
+
+  while (response.position) {
+    console.log(`Fetching next page of usage plans, at position=[${response.position}]`)
+    const nextParams = {...defaultParams, position: response.position}
+    response = await apiGateway.getUsagePlans(nextParams).promise()
+    usagePlans.push(...response.items)
+  }
+
+  return usagePlans
+}
+
+module.exports = { getAllUsagePlans }

--- a/lambdas/catalog-updater/shared/get-all-usage-plans.js
+++ b/lambdas/catalog-updater/shared/get-all-usage-plans.js
@@ -1,0 +1,33 @@
+/**
+ * Fetches all usage plans, combining all pages into a single array.
+ *
+ * @param apiGateway
+ *    an instance of `AWS.APIGateway` to use for API calls
+ *
+ * @param paramOverrides
+ *    a parameter object passed in calls to `APIGateway.getUsagePlans`
+ *
+ * @returns
+ *    a Promise resolving with an array of items returned from
+ *    `APIGateway.getUsagePlans` calls
+ */
+async function getAllUsagePlans(apiGateway, paramOverrides = {}) {
+  // The maximum allowed value of `limit` is 500 according to
+  // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html#getUsagePlans-property
+  const defaultParams = {limit: 500, ...paramOverrides}
+
+  console.log('Fetching first page of usage plans')
+  let response = await apiGateway.getUsagePlans(defaultParams).promise()
+  const usagePlans = response.items
+
+  while (response.position) {
+    console.log(`Fetching next page of usage plans, at position=[${response.position}]`)
+    const nextParams = {...defaultParams, position: response.position}
+    response = await apiGateway.getUsagePlans(nextParams).promise()
+    usagePlans.push(...response.items)
+  }
+
+  return usagePlans
+}
+
+module.exports = { getAllUsagePlans }

--- a/lambdas/shared/__tests__/get-all-usage-plans-test.js
+++ b/lambdas/shared/__tests__/get-all-usage-plans-test.js
@@ -1,0 +1,106 @@
+const { getAllUsagePlans } = require('../get-all-usage-plans')
+
+const promiser = require('../../setup-jest').promiser
+
+const mockUsagePlanItem = () => ({
+  id: '1a2b3c',
+  name: '1a2b3c',
+  apiStages: [
+    {
+      apiId: 'anmlcrckrs',
+      stage: 'prod',
+    },
+    {
+      apiId: 'jlpnochips',
+      stage: 'beta',
+    },
+  ],
+  throttle: {
+    burstLimit: 10,
+    rateLimit: 10,
+  },
+  quota: {
+    limit: 10000,
+    offset: 0,
+    period: 'DAY',
+  }
+})
+
+describe('getAllUsagePlans', () => {
+  test('returns all usage plans, when none exist', async () => {
+    const mockApiGateway = {
+      getUsagePlans: jest.fn().mockReturnValueOnce(promiser({
+        items: []
+      }))
+    }
+
+    const result = await getAllUsagePlans(mockApiGateway)
+    const mocked = mockApiGateway.getUsagePlans.mock
+    expect(mocked.calls.length).toBe(1)
+    expect(mocked.calls[0][0]).not.toHaveProperty('position')
+    expect(result).toHaveLength(0)
+  })
+
+  test('returns all usage plans, when only one page of usage plans exists', async () => {
+    const mockApiGateway = {
+      getUsagePlans: jest.fn().mockReturnValueOnce(promiser({
+        items: [
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+        ]
+      }))
+    }
+
+    const result = await getAllUsagePlans(mockApiGateway)
+    const mocked = mockApiGateway.getUsagePlans.mock
+    expect(mocked.calls.length).toBe(1)
+    expect(mocked.calls[0][0]).not.toHaveProperty('position')
+    expect(result).toHaveLength(4)
+  })
+
+  test('returns all usage plans, when multiple pages of usage plans exist', async () => {
+    const mockApiGateway = {
+      getUsagePlans: jest.fn().mockReturnValueOnce(promiser({
+        items: [
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+        ],
+        position: 'qwertyuiopasdf%3D%3D',
+      })).mockReturnValueOnce(promiser({
+        items: [
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+        ],
+        position: 'zxcvbnm1234567%3D%3D',
+      })).mockReturnValueOnce(promiser({
+        items: [
+          mockUsagePlanItem(),
+          mockUsagePlanItem(),
+        ],
+      }))
+    }
+
+    const result = await getAllUsagePlans(mockApiGateway)
+    const mocked = mockApiGateway.getUsagePlans.mock
+    expect(mocked.calls.length).toBe(3)
+    expect(mocked.calls[0][0]).not.toHaveProperty('position')
+    expect(mocked.calls[1][0]).toHaveProperty('position', 'qwertyuiopasdf%3D%3D')
+    expect(mocked.calls[2][0]).toHaveProperty('position', 'zxcvbnm1234567%3D%3D')
+    expect(result).toHaveLength(10)
+  })
+
+  test('passes through an API Gateway request error', async () => {
+    const expectedError = {}
+    const mockApiGateway = {
+      getUsagePlans: jest.fn().mockReturnValueOnce(promiser(null, expectedError))
+    }
+
+    await expect(getAllUsagePlans(mockApiGateway)).rejects.toStrictEqual(expectedError)
+  })
+})

--- a/lambdas/shared/get-all-usage-plans.js
+++ b/lambdas/shared/get-all-usage-plans.js
@@ -1,0 +1,33 @@
+/**
+ * Fetches all usage plans, combining all pages into a single array.
+ *
+ * @param apiGateway
+ *    an instance of `AWS.APIGateway` to use for API calls
+ *
+ * @param paramOverrides
+ *    a parameter object passed in calls to `APIGateway.getUsagePlans`
+ *
+ * @returns
+ *    a Promise resolving with an array of items returned from
+ *    `APIGateway.getUsagePlans` calls
+ */
+async function getAllUsagePlans(apiGateway, paramOverrides = {}) {
+  // The maximum allowed value of `limit` is 500 according to
+  // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html#getUsagePlans-property
+  const defaultParams = {limit: 500, ...paramOverrides}
+
+  console.log('Fetching first page of usage plans')
+  let response = await apiGateway.getUsagePlans(defaultParams).promise()
+  const usagePlans = response.items
+
+  while (response.position) {
+    console.log(`Fetching next page of usage plans, at position=[${response.position}]`)
+    const nextParams = {...defaultParams, position: response.position}
+    response = await apiGateway.getUsagePlans(nextParams).promise()
+    usagePlans.push(...response.items)
+  }
+
+  return usagePlans
+}
+
+module.exports = { getAllUsagePlans }


### PR DESCRIPTION
Fixes #257.

Previously, whenever we fetched the list of all usage plans (both in the CatalogUpdaterLambda and in the DevPortalLambda), we only fetched the first page. When there are multiple pages of usage plans, some do not appear in the developer portal frontend, nor in the catalog. This PR resolves that issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
