### PR TITLE
Add lambda and script to dump v3 account data

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1483,7 +1483,7 @@ Resources:
       Handler: index.handler
       MemorySize: 512
       Role: !GetAtt DumpV3AccountDataExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 300
       Environment:
         Variables:

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1476,6 +1476,61 @@ Resources:
             # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
             HostedZoneId: 'Z2FDTNDATAQYW2'
 
+  DumpV3AccountDataFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../lambdas/dump-v3-account-data
+      Handler: index.handler
+      MemorySize: 512
+      Role: !GetAtt DumpV3AccountDataExecutionRole.Arn
+      Runtime: nodejs8.10
+      Timeout: 300
+      Environment:
+        Variables:
+          CustomersTableName: !Ref DevPortalCustomersTableName
+          UserPoolId: !Ref CognitoUserPool
+          AdminsGroupName: !Ref CognitoAdminsGroup
+      Layers:
+        - !Ref LambdaCommonLayer
+
+  DumpV3AccountDataExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+      - PolicyName: WriteCloudWatchLogs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+      - PolicyName: ReadCustomersTable
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: dynamodb:Scan
+            Resource: !GetAtt CustomersTable.Arn
+      - PolicyName: ListUserPool
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - cognito-idp:ListUsers
+              - cognito-idp:ListUsersInGroup
+            Resource: !GetAtt CognitoUserPool.Arn
+
 Outputs:
   WebsiteURL:
     Value: !If [ 'DevelopmentMode',

--- a/dev-portal/scripts/dump-v3-account-data.js
+++ b/dev-portal/scripts/dump-v3-account-data.js
@@ -1,0 +1,63 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Calls the DumpV3AccountDataFn lambda, and writes its JSON string output into
+// a file.
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const util = require('util')
+
+const { execute } = require('./utils.js')
+
+const fetchLambdaOutput = async ({ stackName, workDir }) => {
+  const resourceData = JSON.parse((await execute(
+    `aws cloudformation describe-stack-resource`
+    + ` --logical-resource-id DumpV3AccountDataFn`
+    + ` --stack-name ${stackName}`, true)).stdout)
+  const lambdaId = resourceData.StackResourceDetail.PhysicalResourceId
+  const outFile = `${workDir}${path.sep}lambdaOut`
+  await execute(
+    `aws lambda invoke --function-name ${lambdaId} ${outFile}`, true)
+  const output = JSON.parse(fs.readFileSync(outFile))
+  fs.unlinkSync(outFile)
+  return output
+}
+
+const main = async () => {
+  if (process.argv.length !== 4) {
+    const [ node, script ] = process.argv
+    console.error(`Usage: ${node} ${script} STACK_NAME OUTPUT_FILE`)
+    process.exitCode = 127
+    return
+  }
+  const [,, stackName, outFile] = process.argv
+
+  const workDir = await util.promisify(fs.mkdtemp)(os.tmpdir() + path.sep)
+    .catch(error => {
+      throw new Error(`Failed to create temp directory: ${error.message}`)
+    })
+
+  console.log(`Fetching account data from stack ${stackName}...`)
+  const lambdaOutput = await fetchLambdaOutput({ stackName, workDir })
+    .catch(error => {
+      throw new Error(`Failed to fetch account data: ${error.message}`)
+    }).finally(() => fs.rmdirSync(workDir))
+
+  console.log(`Writing account data to ${outFile}...`)
+  try {
+    fs.writeFileSync(outFile, lambdaOutput)
+  } catch (error) {
+    throw new Error(`Failed to write to ${outFile}: ${error.message}`)
+  }
+
+  console.log(`Done.`)
+}
+
+if (!module.parent) {
+  main().catch(error => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/lambdas/common-layer/nodejs/node_modules/dev-portal-common/pager.js
+++ b/lambdas/common-layer/nodejs/node_modules/dev-portal-common/pager.js
@@ -1,9 +1,25 @@
+/**
+ * Returns an array of all items across pages.
+ *
+ *  - The `fetchPage` function may accept a "fetch parameters" object and must
+ *    return a Promise resolving to "page data".
+ *  - The `commonParams` object represents "fetch parameters" which are passed
+ *    to every `fetchPage` call.
+ *  - The `selectItems` function must accept "page data" and must return an
+ *    iterable of the page's items.
+ *  - The `getNextPageParams` function may accept "page data" and must return
+ *    either:
+ *    - a "fetch parameters" object which will be merged with `commonParams` on
+ *      the next call to `fetchPage`, indicating that there is a next page to
+ *      fetch; or
+ *    - a falsy value, to indicate that no next page should be fetched.
+ */
 const fetchAllItems = async ({ fetchPage, commonParams, selectItems, getNextPageParams }) => {
-  let page = await fetchPage(commonParams).promise()
-  const items = selectItems(page)
-  let nextPageParams = getNextPageParams(page)
+  const firstPage = await fetchPage(commonParams).promise()
+  const items = [...selectItems(firstPage)]
+  let nextPageParams = getNextPageParams(firstPage)
   while (nextPageParams) {
-    page = await fetchPage({ ...commonParams, ...nextPageParams }).promise()
+    const page = await fetchPage({ ...commonParams, ...nextPageParams }).promise()
     items.push(...selectItems(page))
     nextPageParams = getNextPageParams(page)
   }

--- a/lambdas/common-layer/nodejs/node_modules/dev-portal-common/pager.js
+++ b/lambdas/common-layer/nodejs/node_modules/dev-portal-common/pager.js
@@ -1,0 +1,42 @@
+const fetchAllItems = async ({ fetchPage, commonParams, selectItems, getNextPageParams }) => {
+  let page = await fetchPage(commonParams).promise()
+  const items = selectItems(page)
+  let nextPageParams = getNextPageParams(page)
+  while (nextPageParams) {
+    page = await fetchPage({ ...commonParams, ...nextPageParams }).promise()
+    items.push(...selectItems(page))
+    nextPageParams = getNextPageParams(page)
+  }
+  return items
+}
+
+const fetchUsersInCognitoUserPoolGroup = ({ cognitoClient, userPoolId, groupName }) => fetchAllItems({
+  fetchPage: params => cognitoClient.listUsersInGroup(params),
+  commonParams: { UserPoolId: userPoolId, GroupName: groupName },
+  selectItems: page => page.Users,
+  getNextPageParams: page => page.NextToken && { NextToken: page.NextToken },
+})
+
+const fetchUsersInCognitoUserPool = ({ cognitoClient, userPoolId }) => fetchAllItems({
+  fetchPage: params => cognitoClient.listUsers(params),
+  commonParams: { UserPoolId: userPoolId },
+  selectItems: page => page.Users,
+  getNextPageParams: page => page.NextToken && { NextToken: page.NextToken }
+})
+
+const fetchItemsInDynamoDbTable = ({ dynamoDbClient, tableName, extraParams = {} }) => fetchAllItems({
+  fetchPage: params => dynamoDbClient.scan(params),
+  commonParams: {
+    ...extraParams,
+    TableName: tableName,
+  },
+  selectItems: page => page.Items,
+  getNextPageParams: page => page.LastEvaluatedKey && { ExclusiveStartKey: page.LastEvaluatedKey },
+})
+
+module.exports = {
+  fetchAllItems,
+  fetchUsersInCognitoUserPoolGroup,
+  fetchUsersInCognitoUserPool,
+  fetchItemsInDynamoDbTable,
+}

--- a/lambdas/dump-v3-account-data/index.js
+++ b/lambdas/dump-v3-account-data/index.js
@@ -1,0 +1,150 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Dumps account data (as defined in v3) from Cognito and DynamoDB, to be used
+// for migration to v4. Outputs tsv as a JSON string.
+
+'use strict';
+
+const AWS = require('aws-sdk')
+const pager = require('dev-portal-common/pager')
+
+const handler = async (_event, _context) => {
+  const {
+    CustomersTableName: customersTableName,
+    UserPoolId: userPoolId,
+    AdminsGroupName: adminsGroupName,
+  } = process.env
+
+  console.log('Got params:')
+  console.log(`customersTableName: ${customersTableName}`)
+  console.log(`userPoolId: ${userPoolId}`)
+  console.log(`adminsGroupName: ${adminsGroupName}`)
+
+  return await
+    fetchAccountData({ customersTableName, userPoolId, adminsGroupName })
+}
+
+/**
+ * Account fields, as they should be written to the exported TSV.
+ */
+const ACCOUNT_DATA_FIELDS = [
+  'emailAddress',
+  'username',
+  'isAdmin',
+  'identityPoolId',
+  'userPoolId',
+  'apiKeyId',
+]
+
+/**
+ * TSV header for account account fields.
+ */
+const ACCOUNT_DATA_TSV_HEADER = ACCOUNT_DATA_FIELDS.join('\t')
+
+const fetchAccountData = async ({ customersTableName, userPoolId, adminsGroupName }) => {
+  const [adminUserIds, accountsFromTable, usernamesByUserId] =
+    await Promise.all([
+      fetchAdminUserIds({ userPoolId, adminsGroupName }),
+      fetchCustomersTableItems({ tableName: customersTableName }),
+      fetchUsernamesByUserId({ userPoolId }),
+    ])
+
+  let accounts = accountsFromTable
+  accounts = insertIsAdmin({ accounts, adminUserIds })
+  accounts = insertUsernames({ accounts, usernamesByUserId })
+
+  const accountsAsTsv =
+    accounts.map(account => accountDataAsTsv(account)).join('\n')
+  return `${ACCOUNT_DATA_TSV_HEADER}\n${accountsAsTsv}\n`
+}
+
+/**
+ * Get the `sub` attribute of a UserType object.
+ *
+ * See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html.
+ */
+const getCognitoUserSub =
+  user => user.Attributes.find(attribute => attribute.Name === 'sub').Value
+
+/**
+ * Fetches the UserPoolIds of all users in the AdminsGroup.
+ */
+const fetchAdminUserIds = async ({ userPoolId, adminsGroupName }) => {
+  const admins = await pager.fetchUsersInCognitoUserPoolGroup({
+    userPoolId,
+    groupName: adminsGroupName,
+    cognitoClient: exports.cognitoClient,
+  })
+  return new Set(admins.map(admin => getCognitoUserSub(admin)))
+}
+
+/**
+ * Fetches all users in the given user pool, and returns a map of UserPoolId
+ * (`cognito:sub`) to Username.
+ */
+const fetchUsernamesByUserId = async ({ userPoolId }) => {
+  const users = await pager.fetchUsersInCognitoUserPool({
+    userPoolId,
+    cognitoClient: exports.cognitoClient,
+  })
+  return new Map(users.map(user => [getCognitoUserSub(user), user.Username]))
+}
+
+/**
+ * Fetches all items from the CustomersTable, unwrapping DDB's datatype marker.
+ */
+const fetchCustomersTableItems = async ({ tableName }) => {
+  const rawItems = await pager.fetchItemsInDynamoDbTable({
+    dynamoDbClient: exports.dynamoDbClient,
+    tableName,
+    extraParams: {
+      Limit: 2,
+      ProjectionExpression: 'Id, UserPoolId, ApiKeyId',
+    },
+  })
+  return rawItems.map(item => ({
+    identityPoolId: item.Id.S,
+    userPoolId: item.UserPoolId.S,
+    apiKeyId: item.ApiKeyId.S,
+  }))
+}
+
+/**
+ * Returns a copy of the `accounts` Array, except each element has `isAdmin`
+ * set to `true` iff its UserPoolId is in the `adminUserIds` set.
+ */
+const insertIsAdmin = ({ adminUserIds, accounts }) => accounts
+  .map(account => ({
+    ...account,
+    isAdmin: adminUserIds.has(account.userPoolId),
+  }))
+
+/**
+ * Returns a copy of the `accounts` array, except each element has `username`
+ * set to the username as specified in the `usernamesByUserId` Map.
+ */
+const insertUsernames = ({ accounts, usernamesByUserId }) => accounts
+  .map(account => ({
+    ...account,
+    username: usernamesByUserId.get(account.userPoolId),
+  }))
+
+/**
+ * Formats an account account object as a string of tab-separated values.
+ *
+ * Note that no escaping is required, since all fields consist of
+ * non-whitespace characters in the printable subset of Unicode. See [1] for
+ * username constraints.
+ *
+ * [1]: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html
+ */
+const accountDataAsTsv = account => ACCOUNT_DATA_FIELDS
+  .map(key => key === 'emailAddress' ? '' : account[key].toString())
+  .join('\t')
+
+exports = module.exports = {
+  cognitoClient: new AWS.CognitoIdentityServiceProvider(),
+  dynamoDbClient: new AWS.DynamoDB(),
+  handler
+}

--- a/lambdas/dump-v3-account-data/index.js
+++ b/lambdas/dump-v3-account-data/index.js
@@ -131,7 +131,7 @@ const insertUsernames = ({ accounts, usernamesByUserId }) => accounts
   }))
 
 /**
- * Formats an account account object as a string of tab-separated values.
+ * Formats an account object as a string of tab-separated values.
  *
  * Note that no escaping is required, since all fields consist of
  * non-whitespace characters in the printable subset of Unicode. See [1] for

--- a/lambdas/jsconfig.json
+++ b/lambdas/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2017"],
+    "module": "commonjs",
+    "target": "es2017",
+    "paths": {
+      "dev-portal-common/*": ["./common-layer/nodejs/node_modules/dev-portal-common/*"]
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*
This PR adds a lambda function (and corresponding script) to dump account data from CustomersTable and from the CognitoUserPool, which will allow Portal owners to migrate their users if they need to change their UserPool in ways which require replacement. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
