### PR TITLE
Implement "Registered Accounts" admin page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,10 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Working off the latest version of the *staging* branch, modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request merging into the *staging* branch, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+4. Run `prettier` on your new code to ensure style consistency. Remember to only reformat files relevant to your changes.
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request merging into the *staging* branch, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -20,6 +20,7 @@ Metadata:
         Parameters:
           - CognitoIdentityPoolName
           - DevPortalCustomersTableName
+          - AccountRegistrationMode
       -
         Label:
           default: "Subscription Notification Configuration"
@@ -126,6 +127,15 @@ Parameters:
       - 'true'
     ConstraintDescription: Malformed input - Parameter DevelopmentMode value must be either 'true' or 'false'
 
+  AccountRegistrationMode:
+    Type: String
+    Description: Methods allowed for account registration. In 'open' mode, any user may register for an account. In 'request' mode, any user may request an account, but an Admin must approve the request in order for the account to perform any privileged actions (like subscribing to an API). In 'invite' mode, users cannot register or request an account; instead, an Admin must send an invite for the user to accept. See the documentation for details.
+    Default: 'open'
+    AllowedValues:
+      - 'open'
+      - 'request'
+      - 'invite'
+
 Conditions:
   UseCustomDomainName: !And [!And [!Not [!Equals [!Ref CustomDomainName, '']], !Not [!Equals [!Ref CustomDomainNameAcmCertArn, '']]], !Condition NotDevelopmentMode]
   NoCustomDomainName: !And [!Not [ !Condition UseCustomDomainName ], !Condition NotDevelopmentMode]
@@ -134,6 +144,7 @@ Conditions:
   DevelopmentMode: !Equals [!Ref DevelopmentMode, 'true']
   NotDevelopmentMode: !Not [!Condition DevelopmentMode]
   InUSEastOne: !Equals [!Ref 'AWS::Region', 'us-east-1']
+  InviteAccountRegistrationMode: !Equals [!Ref AccountRegistrationMode, 'invite']
 
 Resources:
   ApiGatewayApi:
@@ -1068,7 +1079,13 @@ Resources:
       Schema:
         - AttributeDataType: String
           Name: email
-          Required: false
+          Required: true
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: !If [
+          InviteAccountRegistrationMode, 'true', 'false',
+        ]
+      AutoVerifiedAttributes: ['email']
+      UsernameAttributes: ['email']
 
   CognitoUserPoolClient:
     Type: AWS::Cognito::UserPoolClient

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1493,6 +1493,61 @@ Resources:
             # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
             HostedZoneId: 'Z2FDTNDATAQYW2'
 
+  DumpV3AccountDataFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../lambdas/dump-v3-account-data
+      Handler: index.handler
+      MemorySize: 512
+      Role: !GetAtt DumpV3AccountDataExecutionRole.Arn
+      Runtime: nodejs10.x
+      Timeout: 300
+      Environment:
+        Variables:
+          CustomersTableName: !Ref DevPortalCustomersTableName
+          UserPoolId: !Ref CognitoUserPool
+          AdminsGroupName: !Ref CognitoAdminsGroup
+      Layers:
+        - !Ref LambdaCommonLayer
+
+  DumpV3AccountDataExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+      - PolicyName: WriteCloudWatchLogs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+      - PolicyName: ReadCustomersTable
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: dynamodb:Scan
+            Resource: !GetAtt CustomersTable.Arn
+      - PolicyName: ListUserPool
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+              - cognito-idp:ListUsers
+              - cognito-idp:ListUsersInGroup
+            Resource: !GetAtt CognitoUserPool.Arn
+
 Outputs:
   WebsiteURL:
     Value: !If [ 'DevelopmentMode',

--- a/dev-portal/package-lock.json
+++ b/dev-portal/package-lock.json
@@ -4441,6 +4441,15 @@
         "object-assign": "^4.1.1"
       }
     },
+    "create-react-context": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
+      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
+      "requires": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
+      }
+    },
     "cross-fetch": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-0.0.8.tgz",
@@ -6812,6 +6821,11 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gzip-size": {
       "version": "5.0.0",
@@ -10798,6 +10812,11 @@
         "ts-pnp": "^1.0.0"
       }
     },
+    "popper.js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+    },
     "portfinder": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
@@ -12228,6 +12247,19 @@
         }
       }
     },
+    "react-popper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "<=0.2.2",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
+    },
     "react-redux": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.10.tgz",
@@ -13057,17 +13089,18 @@
       }
     },
     "semantic-ui-react": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.85.0.tgz",
-      "integrity": "sha512-rroRoux+MMmLaZCZfFX9xZfTo1cy+JiM55fVaaqbfPq0s0RupraBhamJhvTDz7idl3ionaXPW7knJyZAz4XMGg==",
+      "version": "0.87.3",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.87.3.tgz",
+      "integrity": "sha512-YJgFYEheeFBMm/epZpIpWKF9glgSShdLPiY8zoUi+KJ0IKtLtbI8RbMD/ELbZkY+SO/IWbK/f/86pWt3PVvMVA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "@semantic-ui-react/event-stack": "^3.0.1",
+        "@semantic-ui-react/event-stack": "^3.1.0",
         "classnames": "^2.2.6",
         "keyboard-key": "^1.0.4",
         "lodash": "^4.17.11",
         "prop-types": "^15.6.2",
         "react-is": "^16.7.0",
+        "react-popper": "^1.3.3",
         "shallowequal": "^1.1.0"
       }
     },
@@ -14456,6 +14489,11 @@
           }
         }
       }
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/dev-portal/package.json
+++ b/dev-portal/package.json
@@ -17,7 +17,7 @@
     "react-markdown": "^4.0.3",
     "react-router-dom": "^4.3.1",
     "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "0.85.0",
+    "semantic-ui-react": "^0.87.3",
     "swagger-ui": "git@github.com:Trial-In-Error/swagger-ui.git#a183e909ab467693cb1bbf87d5cc4d1e6b899579",
     "yamljs": "^0.3.0"
   },

--- a/dev-portal/scripts/dump-v3-account-data.js
+++ b/dev-portal/scripts/dump-v3-account-data.js
@@ -1,0 +1,63 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Calls the DumpV3AccountDataFn lambda, and writes its JSON string output into
+// a file.
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const util = require('util')
+
+const { execute } = require('./utils.js')
+
+const fetchLambdaOutput = async ({ stackName, workDir }) => {
+  const resourceData = JSON.parse((await execute(
+    `aws cloudformation describe-stack-resource`
+    + ` --logical-resource-id DumpV3AccountDataFn`
+    + ` --stack-name ${stackName}`, true)).stdout)
+  const lambdaId = resourceData.StackResourceDetail.PhysicalResourceId
+  const outFile = `${workDir}${path.sep}lambdaOut`
+  await execute(
+    `aws lambda invoke --function-name ${lambdaId} ${outFile}`, true)
+  const output = JSON.parse(fs.readFileSync(outFile))
+  fs.unlinkSync(outFile)
+  return output
+}
+
+const main = async () => {
+  if (process.argv.length !== 4) {
+    const [ node, script ] = process.argv
+    console.error(`Usage: ${node} ${script} STACK_NAME OUTPUT_FILE`)
+    process.exitCode = 127
+    return
+  }
+  const [,, stackName, outFile] = process.argv
+
+  const workDir = await util.promisify(fs.mkdtemp)(os.tmpdir() + path.sep)
+    .catch(error => {
+      throw new Error(`Failed to create temp directory: ${error.message}`)
+    })
+
+  console.log(`Fetching account data from stack ${stackName}...`)
+  const lambdaOutput = await fetchLambdaOutput({ stackName, workDir })
+    .catch(error => {
+      throw new Error(`Failed to fetch account data: ${error.message}`)
+    }).finally(() => fs.rmdirSync(workDir))
+
+  console.log(`Writing account data to ${outFile}...`)
+  try {
+    fs.writeFileSync(outFile, lambdaOutput)
+  } catch (error) {
+    throw new Error(`Failed to write to ${outFile}: ${error.message}`)
+  }
+
+  console.log(`Done.`)
+}
+
+if (!module.parent) {
+  main().catch(error => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/dev-portal/src/__tests__/utils.jsx
+++ b/dev-portal/src/__tests__/utils.jsx
@@ -6,7 +6,11 @@ import { render } from '@testing-library/react'
 /*
  * Jest requires at least one test per file in __tests__.
  */
-test('', () => {})
+if (typeof test === 'function') {
+  test('', () => {})
+} else {
+  console.warn('__tests__/utils used outside of tests!')
+}
 
 /*
  * Wrapper around react-testing-library's `render` function, providing a dummy
@@ -14,10 +18,19 @@ test('', () => {})
  *
  * [1]: https://testing-library.com/docs/example-react-router
  */
-export const renderWithRouter = (ui, {
-  route = '/',
-  history = createMemoryHistory({ initialEntries: [route] })
-} = {}) => ({
+export const renderWithRouter = (
+  ui,
+  {
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
+  } = {},
+) => ({
   ...render(<Router history={history}>{ui}</Router>),
-  history
+  history,
 })
+
+/**
+ * Returns a Promise that resolves after `ms` milliseconds with the value `resolution`.
+ */
+export const resolveAfter = (ms, resolution) =>
+  new Promise(resolve => setTimeout(() => resolve(resolution), ms))

--- a/dev-portal/src/components/Admin/Accounts/AccountsTable.jsx
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTable.jsx
@@ -12,6 +12,8 @@ import {
 
 import styles from './AccountsTable.module.css'
 
+export const DEFAULT_PAGE_SIZE = 10
+
 const FILLER_ACCOUNT = Symbol('FILLER_ACCOUNT')
 
 const NO_FILTER_COLUMN = Symbol('NO_FILTER_COLUMN')
@@ -62,7 +64,7 @@ export const AccountsTable = ({
   onSelectAccount,
   children: toolbarActions,
 }) => {
-  const pageSize = 10
+  const pageSize = DEFAULT_PAGE_SIZE
 
   const [accountsView, setAccountsView] = useState(accounts)
   const [activePage, setActivePage] = useState(0)

--- a/dev-portal/src/components/Admin/Accounts/AccountsTable.jsx
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTable.jsx
@@ -97,13 +97,7 @@ export const AccountsTable = ({
     else if (!filterableColumns.includes(filterColumn)) {
       setFilterColumn(NO_FILTER_COLUMN)
     }
-  }, [
-    columns,
-    filterColumn,
-    setFilterColumn,
-    setFilterValue,
-    setFilterableColumns,
-  ])
+  }, [columns, filterColumn])
 
   /**
    * Sets `accountsView` to the filtered and sorted subset of `props.accounts`.
@@ -140,7 +134,7 @@ export const AccountsTable = ({
       }
       return pageItems
     },
-    [accountsView],
+    [accountsView, pageSize],
   )
 
   const totalPages = Math.ceil(accountsView.length / pageSize)

--- a/dev-portal/src/components/Admin/Accounts/AccountsTable.jsx
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTable.jsx
@@ -1,0 +1,327 @@
+import _ from 'lodash'
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  Container,
+  Dropdown,
+  Icon,
+  Input,
+  Pagination,
+  Placeholder,
+  Table,
+} from 'semantic-ui-react'
+
+import styles from './AccountsTable.module.css'
+
+const FILLER_ACCOUNT = Symbol('FILLER_ACCOUNT')
+
+const NO_FILTER_COLUMN = Symbol('NO_FILTER_COLUMN')
+const NO_FILTER_VALUE = ''
+const NO_ORDER_COLUMN = Symbol('NO_ORDER_COLUMN')
+const NO_ORDER_DIRECTION = Symbol('NO_ORDER_DIRECTION')
+
+const NEXT_DIRECTION = {
+  [NO_ORDER_DIRECTION]: 'asc',
+  asc: 'desc',
+  desc: NO_ORDER_DIRECTION,
+}
+
+const DIRECTION_ICON = {
+  [NO_ORDER_DIRECTION]: 'sort',
+  asc: 'sort up',
+  desc: 'sort down',
+}
+
+/**
+ * A paginated table whose rows represent accounts.
+ *
+ * @param {Object} props
+ * @param {Object[]} props.accounts
+ *    all Account objects to display (before filtering)
+ * @param {AccountsTableColumns~Descriptor[]} props.columns
+ *    column descriptors
+ * @param {boolean} props.loading
+ *    if true, the table displays a loading state; if false, the table displays
+ *    the given accounts
+ * @param {Object} props.selectedAccount
+ *    an Account object to highlight
+ * @param onSelectAccount
+ *    when the row corresponding to `account` is clicked, AccountsTable calls
+ *    `onSelectAccount(account)`
+ * @param children
+ *    components to be placed in the actions section above the table
+ */
+export const AccountsTable = ({
+  accounts,
+  columns,
+  loading,
+  selectedAccount,
+  onSelectAccount,
+  children: toolbarActions,
+}) => {
+  const pageSize = 10
+
+  const [accountsView, setAccountsView] = useState(accounts)
+  const [activePage, setActivePage] = useState(0)
+  const [activePageAccounts, setActivePageAccounts] = useState(
+    [...Array(pageSize)].fill(FILLER_ACCOUNT),
+  )
+
+  const [filterableColumns, setFilterableColumns] = useState([])
+  const [filterColumn, setFilterColumn] = useState(NO_FILTER_COLUMN)
+  const [filterValue, setFilterValue] = useState(NO_FILTER_VALUE)
+  const [orderColumn, setOrderColumn] = useState(NO_ORDER_COLUMN)
+  const [orderDirection, setOrderDirection] = useState(NO_ORDER_DIRECTION)
+
+  useEffect(() => {
+    const filterableColumns = columns.filter(column => column.filtering)
+    setFilterableColumns(filterableColumns)
+
+    // Reset filtering state if no columns are filterable
+    if (filterableColumns.length === 0) {
+      setFilterColumn(NO_FILTER_COLUMN)
+      setFilterValue(NO_FILTER_VALUE)
+    }
+
+    // Pick the first filterable column if one is available
+    else if (filterColumn === NO_FILTER_COLUMN) {
+      setFilterColumn(filterableColumns[0])
+    }
+
+    // Reset filterColumn if it's no longer among the available columns
+    else if (!filterableColumns.includes(filterColumn)) {
+      setFilterColumn(NO_FILTER_COLUMN)
+    }
+  }, [
+    columns,
+    filterColumn,
+    setFilterColumn,
+    setFilterValue,
+    setFilterableColumns,
+  ])
+
+  /**
+   * Sets `accountsView` to the filtered and sorted subset of `props.accounts`.
+   */
+  useEffect(() => {
+    let view = _(accounts)
+    if (filterColumn !== NO_FILTER_COLUMN) {
+      const filterKey = filterColumn.filtering.accessor
+      view = view.filter(
+        item =>
+          !!item[filterKey] && item[filterKey].toString().includes(filterValue),
+      )
+    }
+    if (orderColumn !== NO_ORDER_COLUMN) {
+      view = view.orderBy([orderColumn.ordering.iteratee], [orderDirection])
+    }
+    setAccountsView(view.value())
+  }, [accounts, filterColumn, filterValue, orderColumn, orderDirection])
+
+  /**
+   * Returns a page of accounts from `accountView` according to the given page
+   * number.
+   */
+  const computeAccountsPage = useCallback(
+    activePage => {
+      const start = activePage * pageSize
+      const pageItems = accountsView.slice(start, start + pageSize)
+      const fillerCount = pageSize - pageItems.length
+      if (fillerCount) {
+        pageItems.push(...Array(fillerCount).fill(FILLER_ACCOUNT))
+      }
+      return pageItems
+    },
+    [accountsView],
+  )
+
+  const totalPages = Math.ceil(accountsView.length / pageSize)
+
+  const onPageChange = useCallback(
+    (_event, { activePage: newActivePage }) => {
+      // SemanticUI uses 1-indexing in Pagination. We prefer sanity.
+      --newActivePage
+      setActivePage(newActivePage)
+      setActivePageAccounts(computeAccountsPage(newActivePage, accountsView))
+      onSelectAccount(undefined)
+    },
+    [accountsView, onSelectAccount, computeAccountsPage],
+  )
+
+  useEffect(() => {
+    loading || onPageChange(undefined, { activePage: 1 })
+  }, [accounts, loading, onPageChange])
+
+  const tableRows = _.range(pageSize).map(index => {
+    if (loading) {
+      return <LoadingAccountRow key={index} columnCount={columns.length} />
+    }
+
+    const account = activePageAccounts[index]
+    return account === FILLER_ACCOUNT ? (
+      <FillerAccountRow key={index} columnCount={columns.length} />
+    ) : (
+      <AccountRow
+        account={account}
+        columns={columns}
+        isSelected={account === selectedAccount}
+        onSelect={onSelectAccount}
+        key={index}
+      />
+    )
+  })
+
+  const filterColumnDropdownOptions = filterableColumns.map(
+    ({ title, id }, index) => ({ key: index, text: title, value: id }),
+  )
+
+  const onFilterColumnDropdownChange = (_event, { value }) =>
+    setFilterColumn(
+      filterableColumns.find(column => column.id === value) || NO_FILTER_COLUMN,
+    )
+  const onSearchInputChange = (_event, { value }) => setFilterValue(value)
+
+  const toolbar = (
+    <>
+      <div
+        style={{ float: 'left', marginBottom: '1rem', paddingRight: '1rem' }}
+      >
+        {filterableColumns.length > 0 && (
+          <Input
+            iconPosition='left'
+            icon='search'
+            placeholder='Search by...'
+            value={filterValue}
+            onChange={onSearchInputChange}
+            style={{ maxWidth: '24em' }}
+          />
+        )}
+      </div>
+      <div
+        style={{ float: 'left', marginBottom: '1rem', paddingRight: '1rem' }}
+      >
+        <Dropdown
+          onChange={onFilterColumnDropdownChange}
+          options={filterColumnDropdownOptions}
+          selection
+          value={filterColumn.id}
+          data-testid='filterDropdown'
+        />
+      </div>
+      <div style={{ float: 'right', marginBottom: '1rem' }}>
+        {toolbarActions}
+      </div>
+    </>
+  )
+
+  const table = (
+    <Table selectable={!loading} data-testid='accountsTable'>
+      <TableHeader
+        columns={columns}
+        orderColumn={orderColumn}
+        setOrderColumn={setOrderColumn}
+        orderDirection={orderDirection}
+        setOrderDirection={setOrderDirection}
+      />
+      <Table.Body>{tableRows}</Table.Body>
+      <Table.Footer>
+        <Table.Row>
+          <Table.HeaderCell colSpan={columns.length}>
+            <Container fluid textAlign='right'>
+              <Pagination
+                // SemanticUI uses 1-indexing in Pagination. We prefer sanity.
+                activePage={activePage + 1}
+                onPageChange={onPageChange}
+                totalPages={totalPages}
+              />
+            </Container>
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Footer>
+    </Table>
+  )
+
+  return (
+    <Container fluid>
+      {toolbar}
+      {table}
+    </Container>
+  )
+}
+
+const TableHeader = React.memo(
+  ({
+    columns,
+    orderColumn,
+    setOrderColumn,
+    orderDirection,
+    setOrderDirection,
+  }) => {
+    // Clicking on a column makes it the "orderColumn". If that column was
+    // already the "orderColumn", cycle between order directions (none,
+    // ascending, descending). Otherwise, start at the beginning of the cycle
+    // (ascending).
+    const onToggleOrder = column => () => {
+      if (column === orderColumn) {
+        const nextDirection = NEXT_DIRECTION[orderDirection]
+        if (nextDirection === NO_ORDER_DIRECTION) {
+          setOrderColumn(NO_ORDER_COLUMN)
+        }
+        setOrderDirection(nextDirection)
+      } else {
+        setOrderColumn(column)
+        setOrderDirection(NEXT_DIRECTION[NO_ORDER_DIRECTION])
+      }
+    }
+
+    return (
+      <Table.Header>
+        <Table.Row className={styles.headerRow}>
+          {columns.map((column, index) => (
+            <Table.HeaderCell
+              key={index}
+              onClick={column.ordering && onToggleOrder(column)}
+            >
+              {column.title}
+              {column === orderColumn && (
+                <Icon name={DIRECTION_ICON[orderDirection]} />
+              )}
+              {column.ordering && column !== orderColumn && (
+                <Icon name={DIRECTION_ICON[NO_ORDER_DIRECTION]} disabled />
+              )}
+            </Table.HeaderCell>
+          ))}
+        </Table.Row>
+      </Table.Header>
+    )
+  },
+)
+
+const LoadingAccountRow = React.memo(({ columnCount }) => (
+  <Table.Row>
+    {Array.from({ length: columnCount }).map((_value, index) => (
+      <Table.Cell key={index}>
+        <Placeholder data-testid='accountRowPlaceholder' fluid>
+          &nbsp;
+        </Placeholder>
+      </Table.Cell>
+    ))}
+  </Table.Row>
+))
+
+const FillerAccountRow = React.memo(({ columnCount }) => (
+  <Table.Row>
+    {Array.from({ length: columnCount }).map((_value, index) => (
+      <Table.Cell key={index}>&nbsp;</Table.Cell>
+    ))}
+  </Table.Row>
+))
+
+const AccountRow = React.memo(({ account, columns, isSelected, onSelect }) => {
+  return (
+    <Table.Row active={isSelected} onClick={() => onSelect(account)}>
+      {columns.map(({ render }, index) => (
+        <Table.Cell key={index}>{render(account)}</Table.Cell>
+      ))}
+    </Table.Row>
+  )
+})

--- a/dev-portal/src/components/Admin/Accounts/AccountsTable.module.css
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTable.module.css
@@ -1,0 +1,3 @@
+.headerRow {
+  user-select: none;
+}

--- a/dev-portal/src/components/Admin/Accounts/AccountsTableColumns.jsx
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTableColumns.jsx
@@ -1,0 +1,70 @@
+/**
+ * An AccountsTable column descriptor.
+ *
+ * @typedef {Object} AccountsTableColumns~Descriptor
+ * @property {string} id
+ *    a unique ID to distinguish this column from others
+ * @property {string} title
+ *    column title to show in the header row
+ * @property {Function} render
+ *    accepts an Account object, and returns content to be placed in the table
+ *    cell in this column
+ * @property {(Object|undefined)} ordering
+ *    ordering descriptor for this column. If absent, the user cannot order on
+ *    this column.
+ * @property ordering.iteratee
+ *    a lodash iteratee, used with `lodash.orderBy`
+ * @property {(Object|undefined)} filtering
+ *    filtering descriptor for this column. If absent, the user cannot filter
+ *    on this column.
+ * @property {string} filtering.accessor
+ *    an Account object property name on which to search
+ */
+
+export const EmailAddress = {
+  id: 'emailAddress',
+  title: 'Email address',
+  render: account => account.emailAddress,
+  ordering: {
+    iteratee: 'emailAddress',
+  },
+  filtering: {
+    accessor: 'emailAddress',
+  },
+}
+
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat('default', {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+})
+
+const formatDate = isoDateString =>
+  DATE_TIME_FORMATTER.format(new Date(isoDateString))
+
+export const DateRegistered = {
+  id: 'dateRegistered',
+  title: 'Date registered',
+  render: account => formatDate(account.dateRegistered),
+  ordering: {
+    iteratee: 'dateRegistered',
+  },
+}
+
+export const RegistrationMethod = {
+  id: 'registrationMethod',
+  title: 'Registration method',
+  render: account => account.registrationMethod,
+}
+
+export const ApiKeyId = {
+  id: 'apiKeyId',
+  title: 'API key ID',
+  render: account => account.apiKeyId,
+  filtering: {
+    accessor: 'apiKeyId',
+  },
+}

--- a/dev-portal/src/components/MessageList.jsx
+++ b/dev-portal/src/components/MessageList.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+
+export const MessageList = ({ messages, dismissMessage, renderers }) => (
+  <>
+    {messages.map((message, index) => {
+      const { type, ...payload } = message
+      if (renderers[type]) {
+        return (
+          <React.Fragment key={index}>
+            {renderers[type](payload, () => dismissMessage(message))}
+          </React.Fragment>
+        )
+      }
+      throw new Error(`Unknown message type: ${type.toString()}`)
+    })}
+  </>
+)
+
+export const useMessageQueue = initialMessages => {
+  const [messages, setMessages] = useState(initialMessages || [])
+
+  const sendMessage = target => setMessages([...messages, target])
+  const dismissMessage = target => {
+    const deleteIndex = messages.findIndex(message => message === target)
+    if (deleteIndex === -1) {
+      throw new Error('Message not found')
+    }
+    setMessages([
+      ...messages.slice(0, deleteIndex),
+      ...messages.slice(deleteIndex + 1),
+    ])
+  }
+
+  return [messages, sendMessage, dismissMessage]
+}

--- a/dev-portal/src/components/MessageList.jsx
+++ b/dev-portal/src/components/MessageList.jsx
@@ -1,35 +1,29 @@
 import React, { useState } from 'react'
 
-export const MessageList = ({ messages, dismissMessage, renderers }) => (
-  <>
-    {messages.map((message, index) => {
-      const { type, ...payload } = message
-      if (renderers[type]) {
-        return (
-          <React.Fragment key={index}>
-            {renderers[type](payload, () => dismissMessage(message))}
-          </React.Fragment>
-        )
-      }
-      throw new Error(`Unknown message type: ${type.toString()}`)
-    })}
-  </>
-)
+export const MessageList = ({ messages }) =>
+  messages.map((message, index) => (
+    <React.Fragment key={index}>{message}</React.Fragment>
+  ))
 
-export const useMessageQueue = initialMessages => {
-  const [messages, setMessages] = useState(initialMessages || [])
+/**
+ * A Hook for operating a list of "messages" which should be self-dismissable.
+ * Returns `[messages, sendMessage]`, where:
+ *    - `messages` is an array of renderable messages (of type `React.ReactNode`)
+ *    - `sendMessage` is a function which accepts a renderer callback, and
+ *      calls the callback to obtain a renderable message to append to
+ *      `messages`. The renderer callback should accept a `dismiss` function as
+ *      its sole argument, which removes the renderable message from `messages`
+ *      when called.
+ */
+export const useMessages = () => {
+  const [messages, setMessages] = useState([])
 
-  const sendMessage = target => setMessages([...messages, target])
-  const dismissMessage = target => {
-    const deleteIndex = messages.findIndex(message => message === target)
-    if (deleteIndex === -1) {
-      throw new Error('Message not found')
-    }
-    setMessages([
-      ...messages.slice(0, deleteIndex),
-      ...messages.slice(deleteIndex + 1),
-    ])
+  const sendMessage = renderWithDismiss => {
+    const target = renderWithDismiss(() => {
+      setMessages(messages => messages.filter(message => message !== target))
+    })
+    setMessages(messages => [...messages, target])
   }
 
-  return [messages, sendMessage, dismissMessage]
+  return [messages, sendMessage]
 }

--- a/dev-portal/src/pages/Admin/Accounts/AccountInvites.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/AccountInvites.jsx
@@ -1,0 +1,7 @@
+import React, { Component } from 'react'
+
+export default class AccountInvites extends Component {
+  render = () => {
+    return <p>TODO: Account invites</p>
+  }
+}

--- a/dev-portal/src/pages/Admin/Accounts/AccountRequests.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/AccountRequests.jsx
@@ -1,0 +1,7 @@
+import React, { Component } from 'react'
+
+export default class AccountRequests extends Component {
+  render = () => {
+    return <p>TODO: Account requests</p>
+  }
+}

--- a/dev-portal/src/pages/Admin/Accounts/AdminAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/AdminAccounts.jsx
@@ -1,0 +1,7 @@
+import React, { Component } from 'react'
+
+export default class AdminAccounts extends Component {
+  render = () => {
+    return <p>TODO: Admin accounts</p>
+  }
+}

--- a/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
@@ -134,7 +134,7 @@ const DeleteAccountModal = React.memo(
           <p>
             Are you sure you want to delete the account{' '}
             <strong>{account.emailAddress}</strong>, and de-activate the
-            associated API key? This action cannot be undone.
+            associated API key? This action is irreversible.
           </p>
         </Modal.Content>
         <Modal.Actions>
@@ -160,8 +160,8 @@ const PromoteAccountModal = React.memo(
             promoting other accounts.
           </p>
           <p>
-            This action can only be undone by
-            contacting the owner of the Developer Portal.
+            Only the owner of the Developer Portal can demote the account,
+            through the Cognito console.
           </p>
         </Modal.Content>
         <Modal.Actions>

--- a/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
@@ -1,0 +1,245 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Button, Container, Header, Message, Modal } from 'semantic-ui-react'
+
+import * as MessageList from 'components/MessageList'
+import * as AccountService from 'services/accounts'
+import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
+import * as AccountsTableColumns from 'components/Admin/Accounts/AccountsTableColumns'
+
+const RegisteredAccounts = () => {
+  const [accounts, setAccounts] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [selectedAccount, setSelectedAccount] = useState(undefined)
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const [promoteModalOpen, setPromoteModalOpen] = useState(false)
+  const [messages, sendMessage, dismissMessage] = MessageList.useMessageQueue()
+
+  const refreshAccounts = () =>
+    AccountService.fetchRegisteredAccounts().then(accounts =>
+      setAccounts(accounts),
+    )
+
+  // Initial load
+  useEffect(() => {
+    refreshAccounts().finally(() => setLoading(false))
+  }, [])
+
+  const onSelectAccount = useCallback(account => setSelectedAccount(account), [
+    setSelectedAccount,
+  ])
+
+  const onConfirmDelete = useCallback(async () => {
+    setLoading(true)
+    setDeleteModalOpen(false)
+    try {
+      await AccountService.deleteAccountByIdentityPoolId(
+        selectedAccount.identityPoolId,
+      )
+      sendMessage({ type: DELETE_SUCCESS, account: selectedAccount })
+      await refreshAccounts()
+    } catch (error) {
+      sendMessage({
+        type: DELETE_FAILURE,
+        account: selectedAccount,
+        errorMessage: error.message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [sendMessage, selectedAccount])
+
+  const onConfirmPromote = useCallback(async () => {
+    setLoading(true)
+    setPromoteModalOpen(false)
+    try {
+      await AccountService.promoteAccountByIdentityPoolId(
+        selectedAccount.identityPoolId,
+      )
+      sendMessage({ type: PROMOTE_SUCCESS, account: selectedAccount })
+    } catch (error) {
+      sendMessage({
+        type: PROMOTE_FAILURE,
+        account: selectedAccount,
+        errorMessage: error.message,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [sendMessage, selectedAccount])
+
+
+  return (
+    <Container fluid style={{ padding: '2em' }}>
+      <Header as='h1'>Registered accounts</Header>
+      <MessageList.MessageList
+        messages={messages}
+        dismissMessage={dismissMessage}
+        renderers={MESSAGE_RENDERERS}
+      />
+      <AccountsTable.AccountsTable
+        accounts={accounts}
+        columns={[
+          AccountsTableColumns.EmailAddress,
+          AccountsTableColumns.DateRegistered,
+          AccountsTableColumns.RegistrationMethod,
+          AccountsTableColumns.ApiKeyId,
+        ]}
+        loading={loading}
+        selectedAccount={selectedAccount}
+        onSelectAccount={onSelectAccount}
+      >
+        <TableActions
+          canDelete={!loading && selectedAccount}
+          onClickDelete={() => setDeleteModalOpen(true)}
+          canPromote={!loading && selectedAccount}
+          onClickPromote={() => setPromoteModalOpen(true)}
+        />
+      </AccountsTable.AccountsTable>
+      <DeleteAccountModal
+        account={selectedAccount}
+        onConfirm={onConfirmDelete}
+        open={deleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+      />
+      <PromoteAccountModal
+        account={selectedAccount}
+        onConfirm={onConfirmPromote}
+        open={promoteModalOpen}
+        onClose={() => setPromoteModalOpen(false)}
+      />
+    </Container>
+  )
+}
+export default RegisteredAccounts
+
+const TableActions = React.memo(
+  ({ canDelete, onClickDelete, canPromote, onClickPromote }) => (
+    <Button.Group>
+      <Button content='Delete' disabled={!canDelete} onClick={onClickDelete} />
+      <Button
+        content='Promote to Admin'
+        disabled={!canPromote}
+        onClick={onClickPromote}
+      />
+    </Button.Group>
+  ),
+)
+
+const DeleteAccountModal = React.memo(
+  ({ account, onConfirm, open, onClose }) =>
+    account && (
+      <Modal size='small' open={open} onClose={onClose}>
+        <Modal.Header>Confirm deletion</Modal.Header>
+        <Modal.Content>
+          <p>
+            Are you sure you want to delete the account{' '}
+            <strong>{account.emailAddress}</strong>, and de-activate the
+            associated API key? This action cannot be undone.
+          </p>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button negative onClick={onConfirm}>
+            Delete
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    ),
+)
+
+const PromoteAccountModal = React.memo(
+  ({ account, onConfirm, open, onClose }) =>
+    account && (
+      <Modal size='small' open={open} onClose={onClose}>
+        <Modal.Header>Confirm promotion</Modal.Header>
+        <Modal.Content>
+          <p>
+            Are you sure you want to promote the account{' '}
+            <strong>{account.emailAddress}</strong> to Admin? This will allow
+            the account to perform any Admin actions, including deleting and
+            promoting other accounts.
+          </p>
+          <p>
+            This action can only be undone by
+            contacting the owner of the Developer Portal.
+          </p>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button negative onClick={onConfirm}>
+            Promote
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    ),
+)
+
+const DELETE_SUCCESS = Symbol('DELETE_SUCCESS')
+const DELETE_FAILURE = Symbol('DELETE_FAILURE')
+const PROMOTE_SUCCESS = Symbol('PROMOTE_SUCCESS')
+const PROMOTE_FAILURE = Symbol('PROMOTE_FAILURE')
+
+const MESSAGE_RENDERERS = {
+  [DELETE_SUCCESS]: ({ account }, onDismiss) => (
+    <DeleteSuccessMessage account={account} onDismiss={onDismiss} />
+  ),
+  [DELETE_FAILURE]: ({ account, errorMessage }, onDismiss) => (
+    <DeleteFailureMessage
+      account={account}
+      errorMessage={errorMessage}
+      onDismiss={onDismiss}
+    />
+  ),
+  [PROMOTE_SUCCESS]: ({ account }, onDismiss) => (
+    <PromoteSuccessMessage account={account} onDismiss={onDismiss} />
+  ),
+  [PROMOTE_FAILURE]: ({ account, errorMessage }, onDismiss) => (
+    <PromoteFailureMessage
+      account={account}
+      errorMessage={errorMessage}
+      onDismiss={onDismiss}
+    />
+  ),
+}
+
+const DeleteSuccessMessage = React.memo(({ account, onDismiss }) => (
+  <Message onDismiss={onDismiss} positive>
+    <Message.Content>
+      Deleted account <strong>{account.emailAddress}</strong>.
+    </Message.Content>
+  </Message>
+))
+
+const DeleteFailureMessage = React.memo(
+  ({ account, errorMessage, onDismiss }) => (
+    <Message onDismiss={onDismiss} negative>
+      <Message.Content>
+        <p>
+          Failed to delete account <strong>{account.emailAddress}</strong>.
+        </p>
+        {errorMessage && <p>Error message: {errorMessage}</p>}
+      </Message.Content>
+    </Message>
+  ),
+)
+
+const PromoteSuccessMessage = React.memo(({ account, onDismiss }) => (
+  <Message onDismiss={onDismiss} positive>
+    <Message.Content>
+      Promoted account <strong>{account.emailAddress}</strong>.
+    </Message.Content>
+  </Message>
+))
+
+const PromoteFailureMessage = React.memo(
+  ({ account, errorMessage, onDismiss }) => (
+    <Message onDismiss={onDismiss} negative>
+      <Message.Content>
+        <p>
+          Failed to promote account <strong>{account.emailAddress}</strong>.
+        </p>
+        {errorMessage && <p>Error message: {errorMessage}</p>}
+      </Message.Content>
+    </Message>
+  ),
+)

--- a/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
@@ -6,6 +6,11 @@ import * as AccountService from 'services/accounts'
 import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
 import * as AccountsTableColumns from 'components/Admin/Accounts/AccountsTableColumns'
 
+const DELETE_SUCCESS = Symbol('DELETE_SUCCESS')
+const DELETE_FAILURE = Symbol('DELETE_FAILURE')
+const PROMOTE_SUCCESS = Symbol('PROMOTE_SUCCESS')
+const PROMOTE_FAILURE = Symbol('PROMOTE_FAILURE')
+
 const RegisteredAccounts = () => {
   const [accounts, setAccounts] = useState([])
   const [loading, setLoading] = useState(true)
@@ -173,11 +178,6 @@ const PromoteAccountModal = React.memo(
       </Modal>
     ),
 )
-
-const DELETE_SUCCESS = Symbol('DELETE_SUCCESS')
-const DELETE_FAILURE = Symbol('DELETE_FAILURE')
-const PROMOTE_SUCCESS = Symbol('PROMOTE_SUCCESS')
-const PROMOTE_FAILURE = Symbol('PROMOTE_FAILURE')
 
 const MESSAGE_RENDERERS = {
   [DELETE_SUCCESS]: ({ account }, onDismiss) => (

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { renderWithRouter } from 'utils/test-utils'
 
 import RegisteredAccounts from 'pages/Admin/Accounts/RegisteredAccounts'
+import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
 import * as AccountService from 'services/accounts'
 
 jest.mock('services/accounts')
@@ -61,7 +62,7 @@ describe('RegisteredAccounts page', () => {
     const page = renderPage()
     await waitForAccountsToLoad(page)
 
-    _.range(10).forEach(index =>
+    _.range(AccountsTable.DEFAULT_PAGE_SIZE).forEach(index =>
       expect(page.queryByText(`${index}@example.com`)).not.toBeNull(),
     )
   })

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -103,7 +103,7 @@ describe('RegisteredAccounts page', () => {
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
       .orderBy(['emailAddress'], ['asc'])
-      .take(10)
+      .take(AccountsTable.DEFAULT_PAGE_SIZE)
       .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
 
     // Check that last page is correct
@@ -112,7 +112,10 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.click(lastPageButton)
     _(MOCK_ACCOUNTS)
       .orderBy(['emailAddress'], ['asc'])
-      .drop(150)
+      .drop(
+        Math.floor(NUM_MOCK_ACCOUNTS / AccountsTable.DEFAULT_PAGE_SIZE) *
+          AccountsTable.DEFAULT_PAGE_SIZE,
+      )
       .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
 
     // Order descending, go back to first page
@@ -123,7 +126,7 @@ describe('RegisteredAccounts page', () => {
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
       .orderBy(['emailAddress'], ['desc'])
-      .take(10)
+      .take(AccountsTable.DEFAULT_PAGE_SIZE)
       .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
   })
 
@@ -143,7 +146,7 @@ describe('RegisteredAccounts page', () => {
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
       .orderBy('dateRegistered')
-      .take(10)
+      .take(AccountsTable.DEFAULT_PAGE_SIZE)
       .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
   })
 
@@ -160,7 +163,7 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.change(filterInput, { target: { value: '11' } })
     _(MOCK_ACCOUNTS)
       .filter(({ emailAddress }) => emailAddress.includes('11'))
-      .take(10)
+      .take(AccountsTable.DEFAULT_PAGE_SIZE)
       .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
 
     rtl.fireEvent.change(filterInput, { target: { value: '111' } })
@@ -189,7 +192,7 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.change(filterInput, { target: { value: '15' } })
     _(MOCK_ACCOUNTS)
       .filter(({ apiKeyId }) => apiKeyId.includes('15'))
-      .take(10)
+      .take(AccountsTable.DEFAULT_PAGE_SIZE)
       .forEach(({ apiKeyId }) => rtl.getByText(table, apiKeyId))
 
     rtl.fireEvent.change(filterInput, { target: { value: '155' } })
@@ -216,7 +219,7 @@ describe('RegisteredAccounts page', () => {
     _(MOCK_ACCOUNTS)
       .filter(({ emailAddress }) => emailAddress.includes('13'))
       .orderBy('dateRegistered')
-      .take(10)
+      .take(AccountsTable.DEFAULT_PAGE_SIZE)
       .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
   })
 

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import * as rtl from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-import { renderWithRouter } from '__tests__/utils'
+import { renderWithRouter } from 'utils/test-utils'
 
 import RegisteredAccounts from 'pages/Admin/Accounts/RegisteredAccounts'
 import * as AccountService from 'services/accounts'

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -1,0 +1,381 @@
+import _ from 'lodash'
+import React from 'react'
+import * as rtl from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+
+import { renderWithRouter } from '__tests__/utils'
+
+import RegisteredAccounts from 'pages/Admin/Accounts/RegisteredAccounts'
+import * as AccountService from 'services/accounts'
+
+jest.mock('services/accounts')
+
+/**
+ * Suppress React 16.8 act() warnings globally.
+ * The React team's fix won't be out of alpha until 16.9.0.
+ *
+ * See <https://github.com/facebook/react/issues/14769#issuecomment-514589856>
+ */
+const consoleError = console.error
+beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation((...args) => {
+    if (
+      !args[0].includes(
+        'Warning: An update to %s inside a test was not wrapped in act',
+      )
+    ) {
+      consoleError(...args)
+    }
+  })
+})
+
+afterEach(rtl.cleanup)
+
+const renderPage = () => renderWithRouter(<RegisteredAccounts />)
+
+const waitForAccountsToLoad = page =>
+  rtl.waitForElementToBeRemoved(() =>
+    page.queryAllByTestId('accountRowPlaceholder'),
+  )
+
+describe('RegisteredAccounts page', () => {
+  it('renders', async () => {
+    AccountService.fetchRegisteredAccounts = jest.fn().mockResolvedValue([])
+    const page = renderPage()
+    expect(page.baseElement).toBeTruthy()
+  })
+
+  it('initially shows the loading state', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockReturnValue(new Promise(() => {}))
+
+    const page = renderPage()
+    expect(page.queryAllByTestId('accountRowPlaceholder')).not.toHaveLength(0)
+  })
+
+  it('shows the accounts after loading', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+
+    _.range(10).forEach(index =>
+      expect(page.queryByText(`${index}@example.com`)).not.toBeNull(),
+    )
+  })
+
+  it('orders pages for all accounts', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const pagination = page.getByRole('navigation')
+
+    const page1Button = rtl.queryByText(pagination, '1')
+    expect(page1Button).not.toBeNull()
+
+    const page16Button = rtl.queryByText(pagination, '16')
+    expect(page16Button).not.toBeNull()
+    rtl.fireEvent.click(page16Button)
+    expect(
+      page.queryByText(`${NUM_MOCK_ACCOUNTS - 1}@example.com`),
+    ).not.toBeNull()
+  })
+
+  it('orders accounts by email address', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+
+    // Order ascending
+    const table = page.getByTestId('accountsTable')
+    const emailAddressHeader = rtl.getByText(table, 'Email address')
+    rtl.fireEvent.click(emailAddressHeader)
+
+    // Check that first page is correct
+    ;[0, ..._.range(100, 109)]
+      .map(index => `${index}@example.com`)
+      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+
+    // Check that last page is correct
+    const pagination = page.getByRole('navigation')
+    const lastPageButton = rtl.getByLabelText(pagination, 'Last item')
+    rtl.fireEvent.click(lastPageButton)
+    ;[..._.range(94, 100), 9]
+      .map(index => `${index}@example.com`)
+      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+
+    // Order descending, go back to first page
+    rtl.fireEvent.click(emailAddressHeader)
+    const firstPageButton = rtl.getByLabelText(pagination, 'First item')
+    rtl.fireEvent.click(firstPageButton)
+
+    // Check that first page is correct
+    ;[9, ..._.range(99, 90)]
+      .map(index => `${index}@example.com`)
+      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+  })
+
+  it('orders accounts by date registered', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+
+    // Order ascending
+    const table = page.getByTestId('accountsTable')
+    const dateRegisteredHeader = rtl.getByText(table, 'Date registered')
+    rtl.fireEvent.click(dateRegisteredHeader)
+
+    // Check that first page is correct
+    ;[0, 105, 53, 1, 106, 54, 2, 107, 55, 3]
+      .map(index => `${index}@example.com`)
+      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+  })
+
+  it('filters accounts by email address', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const filterInput = page.getByPlaceholderText('Search by...')
+    const table = page.getByTestId('accountsTable')
+
+    rtl.fireEvent.change(filterInput, { target: { value: '11' } })
+    ;[11, ..._.range(110, 119)]
+      .map(index => `${index}@example.com`)
+      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+
+    rtl.fireEvent.change(filterInput, { target: { value: '111' } })
+    rtl.getByText(table, '111@example.com')
+    expect(rtl.getAllByText(table, /@example\.com/)).toHaveLength(1)
+
+    rtl.fireEvent.change(filterInput, { target: { value: 'apiKeyId' } })
+    expect(rtl.queryAllByText(table, /@example\.com/)).toHaveLength(0)
+  })
+
+  it('filters accounts by API key', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const filterInput = page.getByPlaceholderText('Search by...')
+    const filterDropdown = page.getByTestId('filterDropdown')
+    const table = page.getByTestId('accountsTable')
+
+    rtl.fireEvent.click(filterDropdown)
+    const filterByApiKeyIdOption = rtl.getByText(filterDropdown, 'API key ID')
+    rtl.fireEvent.click(filterByApiKeyIdOption)
+
+    rtl.fireEvent.change(filterInput, { target: { value: '15' } })
+    ;[15, 115, ..._.range(150, 157)]
+      .map(index => `apiKeyId${index}`)
+      .forEach(apiKeyId => rtl.getByText(table, apiKeyId))
+
+    rtl.fireEvent.change(filterInput, { target: { value: '155' } })
+    rtl.getByText(table, 'apiKeyId155')
+    expect(rtl.getAllByText(table, /apiKeyId/)).toHaveLength(1)
+
+    rtl.fireEvent.change(filterInput, { target: { value: '@example.com' } })
+    expect(rtl.queryAllByText(table, /apiKeyId/)).toHaveLength(0)
+  })
+
+  it('filters and orders at the same time', async () => {
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const filterInput = page.getByPlaceholderText('Search by...')
+    const table = page.getByTestId('accountsTable')
+    const dateRegisteredHeader = rtl.getByText(table, 'Date registered')
+
+    rtl.fireEvent.change(filterInput, { target: { value: '13' } })
+    rtl.fireEvent.click(dateRegisteredHeader)
+    ;[113, 13, ..._.range(131, 138)]
+      .map(index => `apiKeyId${index}`)
+      .forEach(apiKeyId => rtl.getByText(table, apiKeyId))
+  })
+
+  it('deletes an account', async () => {
+    const targetAccountEmail = '1@example.com'
+    const targetAccountIdentityPoolId = 'identityPoolId1'
+
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+      .mockResolvedValueOnce(
+        MOCK_ACCOUNTS.filter(
+          account => account.emailAddress !== targetAccountEmail,
+        ),
+      )
+    AccountService.deleteAccountByIdentityPoolId = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const table = page.getByTestId('accountsTable')
+    const targetAccountEmailCell = rtl.getByText(table, targetAccountEmail)
+    const deleteButton = page.getByText('Delete')
+
+    expect(deleteButton.disabled === true)
+    rtl.fireEvent.click(targetAccountEmailCell)
+    expect(deleteButton.disabled === false)
+    rtl.fireEvent.click(deleteButton)
+
+    const modal = rtl.getByText(document, 'Confirm deletion').closest('.modal')
+    const confirmDeleteButton = rtl.getByText(modal, 'Delete')
+    rtl.getByText(modal, targetAccountEmail)
+    rtl.fireEvent.click(confirmDeleteButton)
+
+    await waitForAccountsToLoad(page)
+    expect(rtl.queryByText(document, 'Confirm deletion')).toBeNull()
+    expect(
+      AccountService.deleteAccountByIdentityPoolId.mock.calls,
+    ).toHaveLength(1)
+    expect(
+      AccountService.deleteAccountByIdentityPoolId.mock.calls[0][0],
+    ).toEqual(targetAccountIdentityPoolId)
+
+    await rtl.wait(() =>
+      expect(page.getByText(/Deleted account/)).toBeInTheDocument(),
+    )
+    expect(rtl.queryByText(table, targetAccountEmail)).toBeNull()
+  })
+
+  it('shows a message when deletion fails', async () => {
+    const targetAccountEmail = '1@example.com'
+    const errorMessage = 'Something weird happened!'
+
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+    AccountService.deleteAccountByIdentityPoolId = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error(errorMessage)))
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const table = page.getByTestId('accountsTable')
+    const targetAccountEmailCell = rtl.getByText(table, targetAccountEmail)
+    const deleteButton = page.getByText('Delete')
+    rtl.fireEvent.click(targetAccountEmailCell)
+    rtl.fireEvent.click(deleteButton)
+
+    const modal = rtl.getByText(document, 'Confirm deletion').closest('.modal')
+    const confirmDeleteButton = rtl.getByText(modal, 'Delete')
+    rtl.getByText(modal, targetAccountEmail)
+    rtl.fireEvent.click(confirmDeleteButton)
+
+    await waitForAccountsToLoad(page)
+    await rtl.wait(() =>
+      expect(page.getByText(/Failed to delete account/)).toBeInTheDocument(),
+    )
+    expect(rtl.getByText(table, targetAccountEmail)).toBeInTheDocument()
+  })
+
+  it('promotes an account', async () => {
+    const targetAccountEmail = '2@example.com'
+    const targetAccountIdentityPoolId = 'identityPoolId2'
+
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+    AccountService.promoteAccountByIdentityPoolId = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const table = page.getByTestId('accountsTable')
+    const targetAccountEmailCell = rtl.getByText(table, targetAccountEmail)
+    const promoteButton = page.getByText('Promote to Admin')
+
+    expect(promoteButton.disabled === true)
+    rtl.fireEvent.click(targetAccountEmailCell)
+    expect(promoteButton.disabled === false)
+    rtl.fireEvent.click(promoteButton)
+
+    const modal = rtl.getByText(document, 'Confirm promotion').closest('.modal')
+    const confirmPromoteButton = rtl.getByText(modal, 'Promote')
+    rtl.getByText(modal, targetAccountEmail)
+    rtl.fireEvent.click(confirmPromoteButton)
+
+    await waitForAccountsToLoad(page)
+    expect(rtl.queryByText(document, 'Confirm promotion')).toBeNull()
+    expect(
+      AccountService.promoteAccountByIdentityPoolId.mock.calls,
+    ).toHaveLength(1)
+    expect(
+      AccountService.promoteAccountByIdentityPoolId.mock.calls[0][0],
+    ).toEqual(targetAccountIdentityPoolId)
+
+    await rtl.wait(() =>
+      expect(page.getByText(/Promoted account/)).toBeInTheDocument(),
+    )
+    expect(rtl.getByText(table, targetAccountEmail)).toBeInTheDocument()
+  })
+
+  it('shows a message when promotion fails', async () => {
+    const targetAccountEmail = '2@example.com'
+    const errorMessage = 'Something strange occurred.'
+
+    AccountService.fetchRegisteredAccounts = jest
+      .fn()
+      .mockResolvedValueOnce(MOCK_ACCOUNTS)
+    AccountService.deleteAccountByIdentityPoolId = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error(errorMessage)))
+
+    const page = renderPage()
+    await waitForAccountsToLoad(page)
+    const table = page.getByTestId('accountsTable')
+    const targetAccountEmailCell = rtl.getByText(table, targetAccountEmail)
+    const deleteButton = page.getByText('Delete')
+    rtl.fireEvent.click(targetAccountEmailCell)
+    rtl.fireEvent.click(deleteButton)
+
+    const modal = rtl.getByText(document, 'Confirm deletion').closest('.modal')
+    const confirmDeleteButton = rtl.getByText(modal, 'Delete')
+    rtl.getByText(modal, targetAccountEmail)
+    rtl.fireEvent.click(confirmDeleteButton)
+
+    await waitForAccountsToLoad(page)
+    await rtl.wait(() =>
+      expect(page.getByText(/Failed to delete account/)).toBeInTheDocument(),
+    )
+    expect(rtl.getByText(table, targetAccountEmail)).toBeInTheDocument()
+  })
+})
+
+const NUM_MOCK_ACCOUNTS = 157 // should be prime
+
+const MOCK_ACCOUNTS = (() => {
+  const now = Date.now()
+  return Array.from({ length: NUM_MOCK_ACCOUNTS }).map((_value, index) => ({
+    identityPoolId: `identityPoolId${index}`,
+    userPoolId: `userPoolId${index}`,
+    emailAddress: `${index}@example.com`,
+    dateRegistered: new Date(
+      now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000,
+    ).toJSON(),
+    apiKeyId: `apiKeyId${index}`,
+    registrationMethod: _.sample(['open', 'invite', 'request']),
+    isAdmin: index % 20 === 0,
+  }))
+})()

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -101,17 +101,19 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.click(emailAddressHeader)
 
     // Check that first page is correct
-    ;[0, ..._.range(100, 109)]
-      .map(index => `${index}@example.com`)
-      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+    _(MOCK_ACCOUNTS)
+      .orderBy(['emailAddress'], ['asc'])
+      .take(10)
+      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
 
     // Check that last page is correct
     const pagination = page.getByRole('navigation')
     const lastPageButton = rtl.getByLabelText(pagination, 'Last item')
     rtl.fireEvent.click(lastPageButton)
-    ;[..._.range(94, 100), 9]
-      .map(index => `${index}@example.com`)
-      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+    _(MOCK_ACCOUNTS)
+      .orderBy(['emailAddress'], ['asc'])
+      .drop(150)
+      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
 
     // Order descending, go back to first page
     rtl.fireEvent.click(emailAddressHeader)
@@ -119,9 +121,10 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.click(firstPageButton)
 
     // Check that first page is correct
-    ;[9, ..._.range(99, 90)]
-      .map(index => `${index}@example.com`)
-      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+    _(MOCK_ACCOUNTS)
+      .orderBy(['emailAddress'], ['desc'])
+      .take(10)
+      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
   })
 
   it('orders accounts by date registered', async () => {
@@ -138,9 +141,10 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.click(dateRegisteredHeader)
 
     // Check that first page is correct
-    ;[0, 105, 53, 1, 106, 54, 2, 107, 55, 3]
-      .map(index => `${index}@example.com`)
-      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+    _(MOCK_ACCOUNTS)
+      .orderBy('dateRegistered')
+      .take(10)
+      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
   })
 
   it('filters accounts by email address', async () => {
@@ -154,9 +158,10 @@ describe('RegisteredAccounts page', () => {
     const table = page.getByTestId('accountsTable')
 
     rtl.fireEvent.change(filterInput, { target: { value: '11' } })
-    ;[11, ..._.range(110, 119)]
-      .map(index => `${index}@example.com`)
-      .forEach(emailAddress => rtl.getByText(table, emailAddress))
+    _(MOCK_ACCOUNTS)
+      .filter(({ emailAddress }) => emailAddress.includes('11'))
+      .take(10)
+      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
 
     rtl.fireEvent.change(filterInput, { target: { value: '111' } })
     rtl.getByText(table, '111@example.com')
@@ -182,9 +187,10 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.click(filterByApiKeyIdOption)
 
     rtl.fireEvent.change(filterInput, { target: { value: '15' } })
-    ;[15, 115, ..._.range(150, 157)]
-      .map(index => `apiKeyId${index}`)
-      .forEach(apiKeyId => rtl.getByText(table, apiKeyId))
+    _(MOCK_ACCOUNTS)
+      .filter(({ apiKeyId }) => apiKeyId.includes('15'))
+      .take(10)
+      .forEach(({ apiKeyId }) => rtl.getByText(table, apiKeyId))
 
     rtl.fireEvent.change(filterInput, { target: { value: '155' } })
     rtl.getByText(table, 'apiKeyId155')
@@ -207,9 +213,11 @@ describe('RegisteredAccounts page', () => {
 
     rtl.fireEvent.change(filterInput, { target: { value: '13' } })
     rtl.fireEvent.click(dateRegisteredHeader)
-    ;[113, 13, ..._.range(131, 138)]
-      .map(index => `apiKeyId${index}`)
-      .forEach(apiKeyId => rtl.getByText(table, apiKeyId))
+    _(MOCK_ACCOUNTS)
+      .filter(({ emailAddress }) => emailAddress.includes('13'))
+      .orderBy('dateRegistered')
+      .take(10)
+      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
   })
 
   it('deletes an account', async () => {
@@ -366,17 +374,18 @@ describe('RegisteredAccounts page', () => {
 
 const NUM_MOCK_ACCOUNTS = 157 // should be prime
 
-const MOCK_ACCOUNTS = (() => {
-  const now = Date.now()
-  return Array.from({ length: NUM_MOCK_ACCOUNTS }).map((_value, index) => ({
-    identityPoolId: `identityPoolId${index}`,
-    userPoolId: `userPoolId${index}`,
-    emailAddress: `${index}@example.com`,
-    dateRegistered: new Date(
-      now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000,
-    ).toJSON(),
-    apiKeyId: `apiKeyId${index}`,
-    registrationMethod: _.sample(['open', 'invite', 'request']),
-    isAdmin: index % 20 === 0,
-  }))
-})()
+const MOCK_DATES_REGISTERED = (() =>
+  _.range(NUM_MOCK_ACCOUNTS).map(index => {
+    const now = Date.now()
+    return new Date(now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000)
+  }))()
+
+const MOCK_ACCOUNTS = _.range(NUM_MOCK_ACCOUNTS).map(index => ({
+  identityPoolId: `identityPoolId${index}`,
+  userPoolId: `userPoolId${index}`,
+  emailAddress: `${index}@example.com`,
+  dateRegistered: MOCK_DATES_REGISTERED[index].toJSON(),
+  apiKeyId: `apiKeyId${index}`,
+  registrationMethod: _.sample(['open', 'invite', 'request']),
+  isAdmin: index % 20 === 0,
+}))

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -377,11 +377,12 @@ describe('RegisteredAccounts page', () => {
 
 const NUM_MOCK_ACCOUNTS = 157 // should be prime
 
-const MOCK_DATES_REGISTERED = (() =>
-  _.range(NUM_MOCK_ACCOUNTS).map(index => {
-    const now = Date.now()
-    return new Date(now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000)
-  }))()
+const MOCK_DATES_REGISTERED = (() => {
+  const now = Date.now()
+  return _.range(NUM_MOCK_ACCOUNTS).map(
+    index => new Date(now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000),
+  )
+})()
 
 const MOCK_ACCOUNTS = _.range(NUM_MOCK_ACCOUNTS).map(index => ({
   identityPoolId: `identityPoolId${index}`,

--- a/dev-portal/src/pages/Admin/Admin.jsx
+++ b/dev-portal/src/pages/Admin/Admin.jsx
@@ -2,7 +2,12 @@ import React, { Component } from 'react'
 import { BrowserRouter as Router } from 'react-router-dom'
 
 import { ApiManagement, SideNav } from './'
-import { AdminRoute } from './../../';
+import { AdminRoute } from './../../'
+
+import RegisteredAccounts from 'pages/Admin/Accounts/RegisteredAccounts'
+import AdminAccounts from 'pages/Admin/Accounts/AdminAccounts'
+import AccountInvites from 'pages/Admin/Accounts/AccountInvites'
+import AccountRequests from 'pages/Admin/Accounts/AccountRequests'
 
 export class Admin extends Component {
   render() {
@@ -13,6 +18,10 @@ export class Admin extends Component {
           <div style={{ flex: "1 1 auto", overflow: 'auto' }}>
             <AdminRoute exact path="/admin" component={ApiManagement} />
             <AdminRoute path="/admin/apis" component={ApiManagement} />
+            <AdminRoute exact path="/admin/accounts" component={RegisteredAccounts} />
+            <AdminRoute exact path="/admin/accounts/admins" component={AdminAccounts} />
+            <AdminRoute exact path="/admin/accounts/invites" component={AccountInvites} />
+            <AdminRoute exact path="/admin/accounts/requests" component={AccountRequests} />
           </div>
         </div>
       </Router>

--- a/dev-portal/src/pages/Admin/Admin.jsx
+++ b/dev-portal/src/pages/Admin/Admin.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { BrowserRouter as Router } from 'react-router-dom'
 
 import { ApiManagement, SideNav } from './'
-import { AdminRoute } from './../../'
+import { AdminRoute } from 'index'
 
 import RegisteredAccounts from 'pages/Admin/Accounts/RegisteredAccounts'
 import AdminAccounts from 'pages/Admin/Accounts/AdminAccounts'

--- a/dev-portal/src/pages/Admin/SideNav.jsx
+++ b/dev-portal/src/pages/Admin/SideNav.jsx
@@ -7,10 +7,23 @@ import { observer } from 'mobx-react'
 import { Link } from 'react-router-dom'
 import { Menu } from 'semantic-ui-react'
 
-
 export const SideNav = observer(() => (
   isAdmin() &&
   (<Menu inverted vertical borderless attached style={{ flex: "0 0 auto" }}>
     <Menu.Item as={Link} to="/admin/apis">APIs</Menu.Item>
+    <Menu.Item as={Link} to="/admin/accounts">
+      Accounts
+      <Menu.Menu>
+        <Menu.Item as={Link} to="/admin/accounts/admins">
+          Admins
+        </Menu.Item>
+        <Menu.Item as={Link} to="/admin/accounts/invites">
+          Invites
+        </Menu.Item>
+        <Menu.Item as={Link} to="/admin/accounts/requests">
+          Requests
+        </Menu.Item>
+      </Menu.Menu>
+    </Menu.Item>
   </Menu>)
 ))

--- a/dev-portal/src/pages/__tests__/Home.jsx
+++ b/dev-portal/src/pages/__tests__/Home.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import {cleanup} from '@testing-library/react'
+import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
-import {renderWithRouter} from '__tests__/utils'
+import { renderWithRouter } from 'utils/test-utils'
 
-import {fragments} from 'services/get-fragments'
+import { fragments } from 'services/get-fragments'
 
-import {HomePage} from 'pages/Home'
+import { HomePage } from 'pages/Home'
 
 beforeEach(() => {
   // Mock fragment

--- a/dev-portal/src/services/accounts.js
+++ b/dev-portal/src/services/accounts.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-import { resolveAfter } from '__tests__/utils'
+import { resolveAfter } from 'utils/test-utils'
 
 const now = Date.now()
 const numMockAccounts = 157 // should be prime

--- a/dev-portal/src/services/accounts.js
+++ b/dev-portal/src/services/accounts.js
@@ -1,0 +1,49 @@
+import _ from 'lodash'
+
+import { resolveAfter } from '__tests__/utils'
+
+const now = Date.now()
+const numMockAccounts = 157 // should be prime
+const mockData = Array.from({ length: numMockAccounts }).map(
+  (_value, index) => ({
+    identityPoolId: `identityPoolId${index}`,
+    userPoolId: `userPoolId${index}`,
+    emailAddress: `${index}@example.com`,
+    dateRegistered: new Date(
+      now + ((index * 3) % numMockAccounts) * 1000,
+    ).toJSON(),
+    apiKeyId: `apiKeyId${index}`,
+    registrationMethod: _.sample(['open', 'invite', 'request']),
+    isAdmin: index % 20 === 0,
+  }),
+)
+
+export const fetchRegisteredAccounts = () => {
+  return resolveAfter(1500, mockData.slice())
+}
+
+export const deleteAccountByIdentityPoolId = async identityPoolId => {
+  await resolveAfter(1500)
+
+  const accountIndex = mockData.findIndex(account => account.identityPoolId === identityPoolId)
+  if (accountIndex === -1) {
+    throw new Error('Account not found!')
+  }
+  if (identityPoolId.endsWith('10')) {
+    throw new Error('Something weird happened!')
+  }
+  mockData.splice(accountIndex, 1)
+}
+
+export const promoteAccountByIdentityPoolId = async identityPoolId => {
+  await resolveAfter(1500)
+
+  const account = mockData.find(account => account.identityPoolId === identityPoolId)
+  if (account === undefined) {
+    throw new Error('Account not found!')
+  }
+  if (account.isAdmin) {
+    throw new Error('Account is already an Admin!')
+  }
+  account.isAdmin = true
+}

--- a/dev-portal/src/utils/test-utils.jsx
+++ b/dev-portal/src/utils/test-utils.jsx
@@ -3,13 +3,8 @@ import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
 import { render } from '@testing-library/react'
 
-/*
- * Jest requires at least one test per file in __tests__.
- */
-if (typeof test === 'function') {
-  test('', () => {})
-} else {
-  console.warn('__tests__/utils used outside of tests!')
+if (typeof jest !== 'object') {
+  console.warn('test-utils used outside of tests!')
 }
 
 /*

--- a/lambdas/common-layer/nodejs/node_modules/dev-portal-common/pager.js
+++ b/lambdas/common-layer/nodejs/node_modules/dev-portal-common/pager.js
@@ -1,0 +1,58 @@
+/**
+ * Returns an array of all items across pages.
+ *
+ *  - The `fetchPage` function may accept a "fetch parameters" object and must
+ *    return a Promise resolving to "page data".
+ *  - The `commonParams` object represents "fetch parameters" which are passed
+ *    to every `fetchPage` call.
+ *  - The `selectItems` function must accept "page data" and must return an
+ *    iterable of the page's items.
+ *  - The `getNextPageParams` function may accept "page data" and must return
+ *    either:
+ *    - a "fetch parameters" object which will be merged with `commonParams` on
+ *      the next call to `fetchPage`, indicating that there is a next page to
+ *      fetch; or
+ *    - a falsy value, to indicate that no next page should be fetched.
+ */
+const fetchAllItems = async ({ fetchPage, commonParams, selectItems, getNextPageParams }) => {
+  const firstPage = await fetchPage(commonParams).promise()
+  const items = [...selectItems(firstPage)]
+  let nextPageParams = getNextPageParams(firstPage)
+  while (nextPageParams) {
+    const page = await fetchPage({ ...commonParams, ...nextPageParams }).promise()
+    items.push(...selectItems(page))
+    nextPageParams = getNextPageParams(page)
+  }
+  return items
+}
+
+const fetchUsersInCognitoUserPoolGroup = ({ cognitoClient, userPoolId, groupName }) => fetchAllItems({
+  fetchPage: params => cognitoClient.listUsersInGroup(params),
+  commonParams: { UserPoolId: userPoolId, GroupName: groupName },
+  selectItems: page => page.Users,
+  getNextPageParams: page => page.NextToken && { NextToken: page.NextToken },
+})
+
+const fetchUsersInCognitoUserPool = ({ cognitoClient, userPoolId }) => fetchAllItems({
+  fetchPage: params => cognitoClient.listUsers(params),
+  commonParams: { UserPoolId: userPoolId },
+  selectItems: page => page.Users,
+  getNextPageParams: page => page.NextToken && { NextToken: page.NextToken }
+})
+
+const fetchItemsInDynamoDbTable = ({ dynamoDbClient, tableName, extraParams = {} }) => fetchAllItems({
+  fetchPage: params => dynamoDbClient.scan(params),
+  commonParams: {
+    ...extraParams,
+    TableName: tableName,
+  },
+  selectItems: page => page.Items,
+  getNextPageParams: page => page.LastEvaluatedKey && { ExclusiveStartKey: page.LastEvaluatedKey },
+})
+
+module.exports = {
+  fetchAllItems,
+  fetchUsersInCognitoUserPoolGroup,
+  fetchUsersInCognitoUserPool,
+  fetchItemsInDynamoDbTable,
+}

--- a/lambdas/dump-v3-account-data/index.js
+++ b/lambdas/dump-v3-account-data/index.js
@@ -1,0 +1,150 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Dumps account data (as defined in v3) from Cognito and DynamoDB, to be used
+// for migration to v4. Outputs tsv as a JSON string.
+
+'use strict';
+
+const AWS = require('aws-sdk')
+const pager = require('dev-portal-common/pager')
+
+const handler = async (_event, _context) => {
+  const {
+    CustomersTableName: customersTableName,
+    UserPoolId: userPoolId,
+    AdminsGroupName: adminsGroupName,
+  } = process.env
+
+  console.log('Got params:')
+  console.log(`customersTableName: ${customersTableName}`)
+  console.log(`userPoolId: ${userPoolId}`)
+  console.log(`adminsGroupName: ${adminsGroupName}`)
+
+  return await
+    fetchAccountData({ customersTableName, userPoolId, adminsGroupName })
+}
+
+/**
+ * Account fields, as they should be written to the exported TSV.
+ */
+const ACCOUNT_DATA_FIELDS = [
+  'emailAddress',
+  'username',
+  'isAdmin',
+  'identityPoolId',
+  'userPoolId',
+  'apiKeyId',
+]
+
+/**
+ * TSV header for account account fields.
+ */
+const ACCOUNT_DATA_TSV_HEADER = ACCOUNT_DATA_FIELDS.join('\t')
+
+const fetchAccountData = async ({ customersTableName, userPoolId, adminsGroupName }) => {
+  const [adminUserIds, accountsFromTable, usernamesByUserId] =
+    await Promise.all([
+      fetchAdminUserIds({ userPoolId, adminsGroupName }),
+      fetchCustomersTableItems({ tableName: customersTableName }),
+      fetchUsernamesByUserId({ userPoolId }),
+    ])
+
+  let accounts = accountsFromTable
+  accounts = insertIsAdmin({ accounts, adminUserIds })
+  accounts = insertUsernames({ accounts, usernamesByUserId })
+
+  const accountsAsTsv =
+    accounts.map(account => accountDataAsTsv(account)).join('\n')
+  return `${ACCOUNT_DATA_TSV_HEADER}\n${accountsAsTsv}\n`
+}
+
+/**
+ * Get the `sub` attribute of a UserType object.
+ *
+ * See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html.
+ */
+const getCognitoUserSub =
+  user => user.Attributes.find(attribute => attribute.Name === 'sub').Value
+
+/**
+ * Fetches the UserPoolIds of all users in the AdminsGroup.
+ */
+const fetchAdminUserIds = async ({ userPoolId, adminsGroupName }) => {
+  const admins = await pager.fetchUsersInCognitoUserPoolGroup({
+    userPoolId,
+    groupName: adminsGroupName,
+    cognitoClient: exports.cognitoClient,
+  })
+  return new Set(admins.map(admin => getCognitoUserSub(admin)))
+}
+
+/**
+ * Fetches all users in the given user pool, and returns a map of UserPoolId
+ * (`cognito:sub`) to Username.
+ */
+const fetchUsernamesByUserId = async ({ userPoolId }) => {
+  const users = await pager.fetchUsersInCognitoUserPool({
+    userPoolId,
+    cognitoClient: exports.cognitoClient,
+  })
+  return new Map(users.map(user => [getCognitoUserSub(user), user.Username]))
+}
+
+/**
+ * Fetches all items from the CustomersTable, unwrapping DDB's datatype marker.
+ */
+const fetchCustomersTableItems = async ({ tableName }) => {
+  const rawItems = await pager.fetchItemsInDynamoDbTable({
+    dynamoDbClient: exports.dynamoDbClient,
+    tableName,
+    extraParams: {
+      Limit: 2,
+      ProjectionExpression: 'Id, UserPoolId, ApiKeyId',
+    },
+  })
+  return rawItems.map(item => ({
+    identityPoolId: item.Id.S,
+    userPoolId: item.UserPoolId.S,
+    apiKeyId: item.ApiKeyId.S,
+  }))
+}
+
+/**
+ * Returns a copy of the `accounts` Array, except each element has `isAdmin`
+ * set to `true` iff its UserPoolId is in the `adminUserIds` set.
+ */
+const insertIsAdmin = ({ adminUserIds, accounts }) => accounts
+  .map(account => ({
+    ...account,
+    isAdmin: adminUserIds.has(account.userPoolId),
+  }))
+
+/**
+ * Returns a copy of the `accounts` array, except each element has `username`
+ * set to the username as specified in the `usernamesByUserId` Map.
+ */
+const insertUsernames = ({ accounts, usernamesByUserId }) => accounts
+  .map(account => ({
+    ...account,
+    username: usernamesByUserId.get(account.userPoolId),
+  }))
+
+/**
+ * Formats an account object as a string of tab-separated values.
+ *
+ * Note that no escaping is required, since all fields consist of
+ * non-whitespace characters in the printable subset of Unicode. See [1] for
+ * username constraints.
+ *
+ * [1]: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html
+ */
+const accountDataAsTsv = account => ACCOUNT_DATA_FIELDS
+  .map(key => key === 'emailAddress' ? '' : account[key].toString())
+  .join('\t')
+
+exports = module.exports = {
+  cognitoClient: new AWS.CognitoIdentityServiceProvider(),
+  dynamoDbClient: new AWS.DynamoDB(),
+  handler
+}

--- a/lambdas/jsconfig.json
+++ b/lambdas/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2017"],
+    "module": "commonjs",
+    "target": "es2017",
+    "paths": {
+      "dev-portal-common/*": ["./common-layer/nodejs/node_modules/dev-portal-common/*"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3946,6 +3946,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,17 @@
     "fs-extra": "^7.0.1",
     "jest": "^24.8.0",
     "memorystream": "^0.3.1",
+    "prettier": "1.18.2",
     "xml-js": "^1.6.8"
   },
   "dependencies": {
     "request-promise": "^4.2.4"
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "tabWidth": 2,
+    "semi": "false",
+    "singleQuote": "true",
+    "jsxSingleQuote": "true"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "prettier": {
     "trailingComma": "all",
     "tabWidth": 2,
-    "semi": "false",
-    "singleQuote": "true",
-    "jsxSingleQuote": "true"
+    "semi": false,
+    "singleQuote": true,
+    "jsxSingleQuote": true
   }
 }


### PR DESCRIPTION
*Description of changes:*
This PR implements the "Registered Accounts" page for the Dev Portal Account Management dashboard. The diff is big, but the most relevant files are:

- cloudformation/**template.yaml**: Modified to enforce email-address-as-username in the Cognito User Pool.
- dev-portal/src/pages/Admin/Accounts/**RegisteredAccounts.jsx**: The full Registered Accounts list page; wraps the AccountsTable with data fetching and actions/buttons for Delete/Promote functionality.
- dev-portal/src/components/Admin/Accounts/**AccountsTable.jsx**: A reusable table for listing, filtering, and sorting Account data.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
