### PR TITLE
Fix account field names in frontend

### DIFF
--- a/dev-portal/src/components/Admin/Accounts/AccountsTableColumns.jsx
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTableColumns.jsx
@@ -23,95 +23,87 @@
  */
 
 export const EmailAddress = {
-  id: 'emailAddress',
+  id: 'EmailAddress',
   title: 'Email address',
-  render: account => account.emailAddress,
+  render: account => account.EmailAddress,
   ordering: {
-    iteratee: 'emailAddress',
+    iteratee: 'EmailAddress',
   },
   filtering: {
-    accessor: 'emailAddress',
+    accessor: 'EmailAddress',
   },
 }
 
 export const DateRegistered = {
-  id: 'dateRegistered',
+  id: 'DateRegistered',
   title: 'Date registered',
-  render: account => formatDate(account.dateRegistered),
+  render: account => formatDate(account.DateRegistered),
   ordering: {
-    iteratee: 'dateRegistered',
+    iteratee: 'DateRegistered',
   },
 }
 
 export const RegistrationMethod = {
-  id: 'registrationMethod',
+  id: 'RegistrationMethod',
   title: 'Registration method',
-  render: account => account.registrationMethod,
+  render: account => account.RegistrationMethod,
 }
 
 export const ApiKeyId = {
-  id: 'apiKeyId',
+  id: 'ApiKeyId',
   title: 'API key ID',
-  render: account => account.apiKeyId,
+  render: account => account.ApiKeyId,
   filtering: {
-    accessor: 'apiKeyId',
+    accessor: 'ApiKeyId',
   },
 }
 
 export const Promoter = {
-  id: 'promoter',
+  id: 'Promoter',
   title: 'Promoter',
-  render: ({ promoterIdentityPoolId, promoterEmailAddress }) =>
-    promoterIdentityPoolId
-      ? `${promoterEmailAddress} (${promoterIdentityPoolId})`
-      : '',
+  render: ({ PromoterIdentityId, PromoterEmailAddress }) =>
+    PromoterIdentityId ? `${PromoterEmailAddress} (${PromoterIdentityId})` : '',
   filtering: {
-    accessor: ({ promoterIdentityPoolId, promoterEmailAddress }) =>
-      promoterIdentityPoolId
-        ? `${promoterEmailAddress} ${promoterIdentityPoolId}`
-        : '',
+    accessor: ({ PromoterIdentityId, PromoterEmailAddress }) =>
+      PromoterIdentityId ? `${PromoterEmailAddress} ${PromoterIdentityId}` : '',
   },
 }
 
 export const Inviter = {
-  id: 'inviter',
+  id: 'Inviter',
   title: 'Inviter',
-  render: ({ inviterIdentityPoolId, inviterEmailAddress }) =>
-    inviterIdentityPoolId
-      ? `${inviterEmailAddress} (${inviterIdentityPoolId})`
-      : '',
+  render: ({ InviterIdentityId, InviterEmailAddress }) =>
+    InviterIdentityId ? `${InviterEmailAddress} (${InviterIdentityId})` : '',
   filtering: {
-    accessor: ({ inviterIdentityPoolId, inviterEmailAddress }) =>
-      inviterIdentityPoolId
-        ? `${inviterEmailAddress} ${inviterIdentityPoolId}`
-        : '',
+    accessor: ({ InviterIdentityId, InviterEmailAddress }) =>
+      InviterIdentityId ? `${InviterEmailAddress} ${InviterIdentityId}` : '',
   },
 }
 
 export const DatePromoted = {
-  id: 'datePromoted',
+  id: 'DatePromoted',
   title: 'Date promoted',
-  render: ({ datePromoted }) => (datePromoted ? formatDate(datePromoted) : ''),
+  render: ({ DatePromoted }) => (DatePromoted ? formatDate(DatePromoted) : ''),
   ordering: {
-    iteratee: 'datePromoted',
+    iteratee: 'DatePromoted',
   },
 }
 
 export const DateRequested = {
-  id: 'dateRequested',
+  id: 'DateRequested',
   title: 'Date requested',
-  render: account => formatDate(account.dateRequested),
+  render: account => formatDate(account.DateRequested),
   ordering: {
-    iteratee: 'dateRequested',
+    iteratee: 'DateRequested',
   },
 }
 
 export const DateInvited = {
-  id: 'dateInvited',
+  id: 'DateInvited',
   title: 'Date invited',
-  render: account => formatDate(account.dateInvited),
+  render: account => formatDate(account.DateInvited),
   ordering: {
-    iteratee: 'dateInvited',
+    iteratee: 'DateInvited',
   },
 }
 

--- a/dev-portal/src/pages/Admin/Accounts/PendingInvites.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/PendingInvites.jsx
@@ -85,9 +85,7 @@ const PendingInvites = () => {
     setLoading(true)
     closeDeleteModal()
     try {
-      await AccountService.deleteInviteByIdentityPoolId(
-        selectedAccount.identityPoolId,
-      )
+      await AccountService.deleteInviteByIdentityId(selectedAccount.IdentityId)
       sendMessage(dismiss => (
         <DeleteSuccessMessage account={selectedAccount} dismiss={dismiss} />
       ))
@@ -224,7 +222,7 @@ const DeleteInviteModal = ({ account, onConfirm, open, onClose }) =>
       <Modal.Content>
         <p>
           Are you sure you want to delete this account invite for{' '}
-          <strong>{account.emailAddress}</strong>? This action is irreversible.
+          <strong>{account.EmailAddress}</strong>? This action is irreversible.
         </p>
       </Modal.Content>
       <Modal.Actions>
@@ -258,7 +256,7 @@ const CreateFailureMessage = ({ emailAddress, errorMessage, dismiss }) => (
 const DeleteSuccessMessage = ({ account, dismiss }) => (
   <Message onDismiss={dismiss} positive>
     <Message.Content>
-      Deleted account invite for <strong>{account.emailAddress}</strong>.
+      Deleted account invite for <strong>{account.EmailAddress}</strong>.
     </Message.Content>
   </Message>
 )
@@ -268,7 +266,7 @@ const DeleteFailureMessage = ({ account, errorMessage, dismiss }) => (
     <Message.Content>
       <p>
         Failed to delete account invite for{' '}
-        <strong>{account.emailAddress}</strong>.
+        <strong>{account.EmailAddress}</strong>.
       </p>
       {errorMessage && <p>Error message: {errorMessage}</p>}
     </Message.Content>

--- a/dev-portal/src/pages/Admin/Accounts/PendingRequests.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/PendingRequests.jsx
@@ -30,8 +30,8 @@ const PendingRequests = () => {
   const onConfirmApprove = useCallback(async () => {
     setLoading(true)
     try {
-      await AccountService.approveAccountRequestByIdentityPoolId(
-        selectedAccount.identityPoolId,
+      await AccountService.approveAccountRequestByIdentityId(
+        selectedAccount.IdentityId,
       )
       sendMessage(dismiss => (
         <ApproveSuccessMessage account={selectedAccount} dismiss={dismiss} />
@@ -54,8 +54,8 @@ const PendingRequests = () => {
     setLoading(true)
     setDenyModalOpen(false)
     try {
-      await AccountService.denyAccountRequestByIdentityPoolId(
-        selectedAccount.identityPoolId,
+      await AccountService.denyAccountRequestByIdentityId(
+        selectedAccount.IdentityId,
       )
       sendMessage(dismiss => (
         <DenySuccessMessage account={selectedAccount} dismiss={dismiss} />
@@ -127,7 +127,7 @@ const DenyAccountModal = React.memo(
         <Modal.Content>
           <p>
             Are you sure you want to deny this account request? The request will
-            be permanently deleted, and <strong>{account.emailAddress}</strong>{' '}
+            be permanently deleted, and <strong>{account.EmailAddress}</strong>{' '}
             will need to sign up again in order to request an account.
           </p>
         </Modal.Content>
@@ -144,7 +144,7 @@ const DenyAccountModal = React.memo(
 const ApproveSuccessMessage = React.memo(({ account, dismiss }) => (
   <Message onDismiss={dismiss} positive>
     <Message.Content>
-      Approved account request for <strong>{account.emailAddress}</strong>.
+      Approved account request for <strong>{account.EmailAddress}</strong>.
     </Message.Content>
   </Message>
 ))
@@ -155,7 +155,7 @@ const ApproveFailureMessage = React.memo(
       <Message.Content>
         <p>
           Failed to approve account request for{' '}
-          <strong>{account.emailAddress}</strong>.
+          <strong>{account.EmailAddress}</strong>.
         </p>
         {errorMessage && <p>Error message: {errorMessage}</p>}
       </Message.Content>
@@ -166,7 +166,7 @@ const ApproveFailureMessage = React.memo(
 const DenySuccessMessage = React.memo(({ account, dismiss }) => (
   <Message onDismiss={dismiss} positive>
     <Message.Content>
-      Denied account request for <strong>{account.emailAddress}</strong>.
+      Denied account request for <strong>{account.EmailAddress}</strong>.
     </Message.Content>
   </Message>
 ))
@@ -176,7 +176,7 @@ const DenyFailureMessage = React.memo(({ account, errorMessage, dismiss }) => (
     <Message.Content>
       <p>
         Failed to deny account request for{' '}
-        <strong>{account.emailAddress}</strong>.
+        <strong>{account.EmailAddress}</strong>.
       </p>
       {errorMessage && <p>Error message: {errorMessage}</p>}
     </Message.Content>

--- a/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/RegisteredAccounts.jsx
@@ -32,9 +32,7 @@ const RegisteredAccounts = () => {
     setLoading(true)
     setDeleteModalOpen(false)
     try {
-      await AccountService.deleteAccountByIdentityPoolId(
-        selectedAccount.identityPoolId,
-      )
+      await AccountService.deleteAccountByIdentityId(selectedAccount.IdentityId)
       sendMessage(dismiss => (
         <DeleteSuccessMessage account={selectedAccount} dismiss={dismiss} />
       ))
@@ -56,8 +54,8 @@ const RegisteredAccounts = () => {
     setLoading(true)
     setPromoteModalOpen(false)
     try {
-      await AccountService.promoteAccountByIdentityPoolId(
-        selectedAccount.identityPoolId,
+      await AccountService.promoteAccountByIdentityId(
+        selectedAccount.IdentityId,
       )
       sendMessage(dismiss => (
         <PromoteSuccessMessage account={selectedAccount} dismiss={dismiss} />
@@ -136,7 +134,7 @@ const DeleteAccountModal = React.memo(
         <Modal.Content>
           <p>
             Are you sure you want to delete the account{' '}
-            <strong>{account.emailAddress}</strong>, and de-activate the
+            <strong>{account.EmailAddress}</strong>, and de-activate the
             associated API key? This action is irreversible.
           </p>
         </Modal.Content>
@@ -158,7 +156,7 @@ const PromoteAccountModal = React.memo(
         <Modal.Content>
           <p>
             Are you sure you want to promote the account{' '}
-            <strong>{account.emailAddress}</strong> to Admin? This will allow
+            <strong>{account.EmailAddress}</strong> to Admin? This will allow
             the account to perform any Admin actions, including deleting and
             promoting other accounts.
           </p>
@@ -180,7 +178,7 @@ const PromoteAccountModal = React.memo(
 const DeleteSuccessMessage = React.memo(({ account, dismiss }) => (
   <Message onDismiss={dismiss} positive>
     <Message.Content>
-      Deleted account <strong>{account.emailAddress}</strong>.
+      Deleted account <strong>{account.EmailAddress}</strong>.
     </Message.Content>
   </Message>
 ))
@@ -190,7 +188,7 @@ const DeleteFailureMessage = React.memo(
     <Message onDismiss={dismiss} negative>
       <Message.Content>
         <p>
-          Failed to delete account <strong>{account.emailAddress}</strong>.
+          Failed to delete account <strong>{account.EmailAddress}</strong>.
         </p>
         {errorMessage && <p>Error message: {errorMessage}</p>}
       </Message.Content>
@@ -201,7 +199,7 @@ const DeleteFailureMessage = React.memo(
 const PromoteSuccessMessage = React.memo(({ account, dismiss }) => (
   <Message onDismiss={dismiss} positive>
     <Message.Content>
-      Promoted account <strong>{account.emailAddress}</strong>.
+      Promoted account <strong>{account.EmailAddress}</strong>.
     </Message.Content>
   </Message>
 ))
@@ -211,7 +209,7 @@ const PromoteFailureMessage = React.memo(
     <Message onDismiss={dismiss} negative>
       <Message.Content>
         <p>
-          Failed to promote account <strong>{account.emailAddress}</strong>.
+          Failed to promote account <strong>{account.EmailAddress}</strong>.
         </p>
         {errorMessage && <p>Error message: {errorMessage}</p>}
       </Message.Content>

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/AdminAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/AdminAccounts.jsx
@@ -9,6 +9,7 @@ import * as accountsTestUtils from 'utils/accounts-test-utils'
 import AdminAccounts from 'pages/Admin/Accounts/AdminAccounts'
 import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
 import * as AccountService from 'services/accounts'
+import * as AccountsTableColumns from 'components/Admin/Accounts/AccountsTableColumns'
 
 jest.mock('services/accounts')
 
@@ -45,8 +46,8 @@ describe('AdminAccounts page', () => {
     await accountsTestUtils.waitForAccountsToLoad(page)
 
     _.take(MOCK_ADMINS, AccountsTable.DEFAULT_PAGE_SIZE).forEach(
-      ({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, page.baseElement),
+      ({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, page.baseElement),
     )
   })
 
@@ -83,10 +84,10 @@ describe('AdminAccounts page', () => {
 
     // Check that first page is correct
     _(MOCK_ADMINS)
-      .orderBy(['emailAddress'])
+      .orderBy(['EmailAddress'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     // Check that last page is correct
@@ -94,13 +95,13 @@ describe('AdminAccounts page', () => {
     const lastPageButton = rtl.getByLabelText(pagination, 'Last item')
     rtl.fireEvent.click(lastPageButton)
     _(MOCK_ADMINS)
-      .orderBy(['emailAddress'])
+      .orderBy(['EmailAddress'])
       .drop(
         Math.floor(MOCK_ADMINS.length / AccountsTable.DEFAULT_PAGE_SIZE) *
           AccountsTable.DEFAULT_PAGE_SIZE,
       )
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     // Order descending, go back to first page
@@ -110,10 +111,10 @@ describe('AdminAccounts page', () => {
 
     // Check that first page is correct
     _(MOCK_ADMINS)
-      .orderBy(['emailAddress'], ['desc'])
+      .orderBy(['EmailAddress'], ['desc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
   })
 
@@ -132,10 +133,10 @@ describe('AdminAccounts page', () => {
 
     // Check that first page is correct
     _(MOCK_ADMINS)
-      .orderBy(['datePromoted'], ['asc'])
+      .orderBy(['DatePromoted'], ['asc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
   })
 
@@ -151,18 +152,20 @@ describe('AdminAccounts page', () => {
 
     rtl.fireEvent.change(filterInput, { target: { value: '1' } })
     _(MOCK_ADMINS)
-      .filter(({ emailAddress }) => emailAddress.includes('1'))
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .filter(({ EmailAddress }) => EmailAddress.includes('1'))
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     rtl.fireEvent.change(filterInput, { target: { value: '9' } })
     expect(
-      accountsTestUtils.queryAllByColumnText(
-        table,
-        'emailAddress',
-        /@example\.com/,
-      ).map(el => el.textContent),
+      accountsTestUtils
+        .queryAllByColumnText(
+          table,
+          AccountsTableColumns.EmailAddress.id,
+          /@example\.com/,
+        )
+        .map(el => el.textContent),
     ).toEqual(['90@example.com'])
   })
 
@@ -186,13 +189,13 @@ describe('AdminAccounts page', () => {
     rtl.fireEvent.change(filterInput, { target: { value: '20@example.com' } })
     _(MOCK_ADMINS)
       .filter({ promoterEmailAddress: '20@example.com' })
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
     expect(
       accountsTestUtils.queryAllByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         /@example\.com/,
       ),
     ).toHaveLength(3)
@@ -201,7 +204,7 @@ describe('AdminAccounts page', () => {
     expect(
       accountsTestUtils.queryAllByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         /@example\.com/,
       ),
     ).toHaveLength(0)
@@ -224,29 +227,31 @@ describe('AdminAccounts page', () => {
     const filterByApiKeyIdOption = rtl.getByText(filterDropdown, 'Promoter')
     rtl.fireEvent.click(filterByApiKeyIdOption)
 
-    rtl.fireEvent.change(filterInput, { target: { value: 'identityPoolId20' } })
+    rtl.fireEvent.change(filterInput, { target: { value: 'identityId20' } })
     const expectedEmails = _(MOCK_ADMINS)
-      .filter(({ promoterIdentityPoolId }) =>
-        (promoterIdentityPoolId || '').includes('identityPoolId20'),
+      .filter(({ PromoterIdentityId }) =>
+        (PromoterIdentityId || '').includes('identityId20'),
       )
-      .map(({ emailAddress }) => emailAddress)
+      .map(({ EmailAddress }) => EmailAddress)
       .sortBy()
       .value()
     expect(
       _.sortBy(
-        accountsTestUtils.queryAllByColumnText(
-          table,
-          'emailAddress',
-          /@example\.com/,
-        ).map(el => el.textContent),
+        accountsTestUtils
+          .queryAllByColumnText(
+            table,
+            AccountsTableColumns.EmailAddress.id,
+            /@example\.com/,
+          )
+          .map(el => el.textContent),
       ),
     ).toEqual(expectedEmails)
 
-    rtl.fireEvent.change(filterInput, { target: { value: 'identityPoolId30' } })
+    rtl.fireEvent.change(filterInput, { target: { value: 'identityId30' } })
     expect(
       accountsTestUtils.queryAllByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         /@example\.com/,
       ),
     ).toHaveLength(0)
@@ -277,19 +282,19 @@ const MOCK_DATES_PROMOTED = (() => {
 
 const MOCK_ADMIN_STEP = 10
 
-const MOCK_ACCOUNTS = (() => {
-  return Array.from({ length: NUM_MOCK_ACCOUNTS }).map((_value, index) => {
+const MOCK_ACCOUNTS = _.range(0, NUM_MOCK_ACCOUNTS, MOCK_ADMIN_STEP).map(
+  index => {
     const promoter = MOCK_PROMOTERS[index]
     return {
-      identityPoolId: `identityPoolId${index}`,
-      userPoolId: `userPoolId${index}`,
-      emailAddress: `${index}@example.com`,
-      datePromoted: MOCK_DATES_PROMOTED[index],
-      promoterEmailAddress: promoter && `${promoter}@example.com`,
-      promoterIdentityPoolId: promoter && `identityPoolId${promoter}`,
+      IdentityId: `identityId${index}`,
+      UserId: `userId${index}`,
+      EmailAddress: `${index}@example.com`,
+      DatePromoted: MOCK_DATES_PROMOTED[index],
+      PromoterEmailAddress: promoter && `${promoter}@example.com`,
+      PromoterIdentityId: promoter && `identityId${promoter}`,
       isAdmin: index % MOCK_ADMIN_STEP === 0,
     }
-  })
-})()
+  },
+)
 
 const MOCK_ADMINS = MOCK_ACCOUNTS.filter(account => account.isAdmin)

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/PendingInvites.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/PendingInvites.jsx
@@ -9,6 +9,7 @@ import * as accountsTestUtils from 'utils/accounts-test-utils'
 import PendingInvites from 'pages/Admin/Accounts/PendingInvites'
 import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
 import * as AccountService from 'services/accounts'
+import * as AccountsTableColumns from 'components/Admin/Accounts/AccountsTableColumns'
 
 jest.mock('services/accounts')
 
@@ -45,8 +46,8 @@ describe('PendingInvites page', () => {
     await accountsTestUtils.waitForAccountsToLoad(page)
 
     _.take(MOCK_ACCOUNTS, AccountsTable.DEFAULT_PAGE_SIZE).forEach(
-      ({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, page.baseElement),
+      ({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, page.baseElement),
     )
   })
 
@@ -83,10 +84,10 @@ describe('PendingInvites page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'])
+      .orderBy(['EmailAddress'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     // Check that last page is correct
@@ -94,13 +95,13 @@ describe('PendingInvites page', () => {
     const lastPageButton = rtl.getByLabelText(pagination, 'Last item')
     rtl.fireEvent.click(lastPageButton)
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'])
+      .orderBy(['EmailAddress'])
       .drop(
         Math.floor(MOCK_ACCOUNTS.length / AccountsTable.DEFAULT_PAGE_SIZE) *
           AccountsTable.DEFAULT_PAGE_SIZE,
       )
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     // Order descending, go back to first page
@@ -110,10 +111,10 @@ describe('PendingInvites page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'], ['desc'])
+      .orderBy(['EmailAddress'], ['desc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
   })
 
@@ -132,10 +133,10 @@ describe('PendingInvites page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['dateInvited'], ['asc'])
+      .orderBy(['DateInvited'], ['asc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
   })
 
@@ -151,16 +152,20 @@ describe('PendingInvites page', () => {
 
     rtl.fireEvent.change(filterInput, { target: { value: '1' } })
     _(MOCK_ACCOUNTS)
-      .filter(({ emailAddress }) => emailAddress.includes('1'))
+      .filter(({ EmailAddress }) => EmailAddress.includes('1'))
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     rtl.fireEvent.change(filterInput, { target: { value: '90' } })
     expect(
       accountsTestUtils
-        .queryAllByColumnText(table, 'emailAddress', /@example\.com/)
+        .queryAllByColumnText(
+          table,
+          AccountsTableColumns.EmailAddress.id,
+          /@example\.com/,
+        )
         .map(el => el.textContent),
     ).toEqual(['90@example.com'])
   })
@@ -186,8 +191,8 @@ describe('PendingInvites page', () => {
     _(MOCK_ACCOUNTS)
       .filter({ inviterEmailAddress: '20@example.com' })
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     rtl.fireEvent.change(filterInput, { target: { value: '30@example.com' } })
@@ -211,12 +216,12 @@ describe('PendingInvites page', () => {
       .fn()
       .mockImplementation(emailAddress => {
         createdAccounts.push({
-          identityPoolId: `createedIdentityId${createdAccounts.length}`,
-          userPoolId: `createdUserId${createdAccounts.length}`,
-          emailAddress: emailAddress,
-          dateInvited: new Date(),
-          inviterEmailAddress: 'you@example.com',
-          inviterIdentityPoolId: 'me',
+          IdentityId: `createedIdentityId${createdAccounts.length}`,
+          UserId: `createdUserId${createdAccounts.length}`,
+          EmailAddress: emailAddress,
+          DateInvited: new Date(),
+          InviterEmailAddress: 'you@example.com',
+          InviterIdentityId: 'me',
         })
       })
 
@@ -348,15 +353,14 @@ describe('PendingInvites page', () => {
       .mockImplementation(() =>
         Promise.resolve(
           MOCK_ACCOUNTS.filter(
-            ({ identityPoolId }) =>
-              !deletedIdentityIds.includes(identityPoolId),
+            ({ IdentityId }) => !deletedIdentityIds.includes(IdentityId),
           ),
         ),
       )
-    AccountService.deleteInviteByIdentityPoolId = jest
+    AccountService.deleteInviteByIdentityId = jest
       .fn()
-      .mockImplementation(identityPoolId => {
-        deletedIdentityIds.push(identityPoolId)
+      .mockImplementation(identityId => {
+        deletedIdentityIds.push(identityId)
       })
 
     const page = renderPage()
@@ -367,7 +371,7 @@ describe('PendingInvites page', () => {
 
     const targetAccountEmailCell = accountsTestUtils.queryByColumnText(
       page.baseElement,
-      'emailAddress',
+      AccountsTableColumns.EmailAddress.id,
       '5@example.com',
     )
     expect(targetAccountEmailCell).toBeInTheDocument()
@@ -404,7 +408,7 @@ describe('PendingInvites page', () => {
     expect(
       accountsTestUtils.queryByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         '5@example.com',
       ),
     ).toBeNull()
@@ -414,7 +418,7 @@ describe('PendingInvites page', () => {
     AccountService.fetchPendingInviteAccounts = jest
       .fn()
       .mockResolvedValue(MOCK_ACCOUNTS)
-    AccountService.deleteInviteByIdentityPoolId = jest
+    AccountService.deleteInviteByIdentityId = jest
       .fn()
       .mockRejectedValue(new Error('Target lost.'))
 
@@ -423,7 +427,7 @@ describe('PendingInvites page', () => {
 
     const targetAccountEmailCell = accountsTestUtils.queryByColumnText(
       page.baseElement,
-      'emailAddress',
+      AccountsTableColumns.EmailAddress.id,
       '2@example.com',
     )
     expect(targetAccountEmailCell).toBeInTheDocument()
@@ -473,10 +477,10 @@ const MOCK_DATES_INVITED = (() => {
 })()
 
 const MOCK_ACCOUNTS = MOCK_INVITERS.map((inviter, index) => ({
-  identityPoolId: `identityPoolId${index}`,
-  userPoolId: `userPoolId${index}`,
-  emailAddress: `${index}@example.com`,
-  dateInvited: MOCK_DATES_INVITED[index],
-  inviterEmailAddress: inviter && `${inviter}@example.com`,
-  inviterIdentityPoolId: inviter && `identityPoolId${inviter}`,
+  IdentityId: `identityId${index}`,
+  UserId: `userId${index}`,
+  EmailAddress: `${index}@example.com`,
+  DateInvited: MOCK_DATES_INVITED[index],
+  InviterEmailAddress: inviter && `${inviter}@example.com`,
+  InviterIdentityId: inviter && `identityId${inviter}`,
 }))

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/PendingRequests.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/PendingRequests.jsx
@@ -9,6 +9,7 @@ import * as accountsTestUtils from 'utils/accounts-test-utils'
 import PendingRequests from 'pages/Admin/Accounts/PendingRequests'
 import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
 import * as AccountService from 'services/accounts'
+import * as AccountsTableColumns from 'components/Admin/Accounts/AccountsTableColumns'
 
 jest.mock('services/accounts')
 
@@ -45,8 +46,8 @@ describe('PendingRequests page', () => {
     await accountsTestUtils.waitForAccountsToLoad(page)
 
     _.take(MOCK_ACCOUNTS, AccountsTable.DEFAULT_PAGE_SIZE).forEach(
-      ({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, page.baseElement),
+      ({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, page.baseElement),
     )
   })
 
@@ -83,10 +84,10 @@ describe('PendingRequests page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'])
+      .orderBy(['EmailAddress'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     // Check that last page is correct
@@ -94,13 +95,13 @@ describe('PendingRequests page', () => {
     const lastPageButton = rtl.getByLabelText(pagination, 'Last item')
     rtl.fireEvent.click(lastPageButton)
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'])
+      .orderBy(['EmailAddress'])
       .drop(
         Math.floor(MOCK_ACCOUNTS.length / AccountsTable.DEFAULT_PAGE_SIZE) *
           AccountsTable.DEFAULT_PAGE_SIZE,
       )
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     // Order descending, go back to first page
@@ -110,10 +111,10 @@ describe('PendingRequests page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'], ['desc'])
+      .orderBy(['EmailAddress'], ['desc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
   })
 
@@ -132,10 +133,10 @@ describe('PendingRequests page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['dateRequested'], ['asc'])
+      .orderBy(['DateRequested'], ['asc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
   })
 
@@ -151,16 +152,20 @@ describe('PendingRequests page', () => {
 
     rtl.fireEvent.change(filterInput, { target: { value: '1' } })
     _(MOCK_ACCOUNTS)
-      .filter(({ emailAddress }) => emailAddress.includes('1'))
+      .filter(({ EmailAddress }) => EmailAddress.includes('1'))
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) =>
-        accountsTestUtils.expectEmailIn(emailAddress, table),
+      .forEach(({ EmailAddress }) =>
+        accountsTestUtils.expectEmailIn(EmailAddress, table),
       )
 
     rtl.fireEvent.change(filterInput, { target: { value: '90' } })
     expect(
       accountsTestUtils
-        .queryAllByColumnText(table, 'emailAddress', /@example\.com/)
+        .queryAllByColumnText(
+          table,
+          AccountsTableColumns.EmailAddress.id,
+          /@example\.com/,
+        )
         .map(el => el.textContent),
     ).toEqual(['90@example.com'])
   })
@@ -174,12 +179,12 @@ describe('PendingRequests page', () => {
           MOCK_ACCOUNTS.filter(
             account =>
               !deletedEmails.some(
-                deletedEmail => account.emailAddress === deletedEmail,
+                deletedEmail => account.EmailAddress === deletedEmail,
               ),
           ),
         ),
       )
-    AccountService.denyAccountRequestByIdentityPoolId = jest
+    AccountService.denyAccountRequestByIdentityId = jest
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
@@ -208,7 +213,7 @@ describe('PendingRequests page', () => {
     expect(
       accountsTestUtils.queryByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         '3@example.com',
       ),
     ).toBeNull()
@@ -230,14 +235,14 @@ describe('PendingRequests page', () => {
     expect(
       accountsTestUtils.queryByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         '3@example.com',
       ),
     ).toBeNull()
     expect(
       accountsTestUtils.queryByColumnText(
         table,
-        'emailAddress',
+        AccountsTableColumns.EmailAddress.id,
         '4@example.com',
       ),
     ).toBeNull()
@@ -256,10 +261,10 @@ const MOCK_DATES_REQUESTED = (() => {
 const MOCK_ACCOUNTS = (() => {
   return Array.from({ length: NUM_MOCK_ACCOUNTS }).map((_value, index) => {
     return {
-      identityPoolId: `identityPoolId${index}`,
-      userPoolId: `userPoolId${index}`,
-      emailAddress: `${index}@example.com`,
-      dateRequested: MOCK_DATES_REQUESTED[index],
+      IdentityId: `identityId${index}`,
+      UserId: `userId${index}`,
+      EmailAddress: `${index}@example.com`,
+      DateRequested: MOCK_DATES_REQUESTED[index],
     }
   })
 })()

--- a/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
+++ b/dev-portal/src/pages/Admin/Accounts/__tests__/RegisteredAccounts.jsx
@@ -9,6 +9,7 @@ import * as accountsTestUtils from 'utils/accounts-test-utils'
 import RegisteredAccounts from 'pages/Admin/Accounts/RegisteredAccounts'
 import * as AccountsTable from 'components/Admin/Accounts/AccountsTable'
 import * as AccountService from 'services/accounts'
+import * as AccountsTableColumns from 'components/Admin/Accounts/AccountsTableColumns'
 
 jest.mock('services/accounts')
 
@@ -82,21 +83,21 @@ describe('RegisteredAccounts page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'], ['asc'])
+      .orderBy(['EmailAddress'], ['asc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
+      .forEach(({ EmailAddress }) => rtl.getByText(table, EmailAddress))
 
     // Check that last page is correct
     const pagination = page.getByRole('navigation')
     const lastPageButton = rtl.getByLabelText(pagination, 'Last item')
     rtl.fireEvent.click(lastPageButton)
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'], ['asc'])
+      .orderBy(['EmailAddress'], ['asc'])
       .drop(
         Math.floor(NUM_MOCK_ACCOUNTS / AccountsTable.DEFAULT_PAGE_SIZE) *
           AccountsTable.DEFAULT_PAGE_SIZE,
       )
-      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
+      .forEach(({ EmailAddress }) => rtl.getByText(table, EmailAddress))
 
     // Order descending, go back to first page
     rtl.fireEvent.click(emailAddressHeader)
@@ -105,9 +106,9 @@ describe('RegisteredAccounts page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy(['emailAddress'], ['desc'])
+      .orderBy(['EmailAddress'], ['desc'])
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
+      .forEach(({ EmailAddress }) => rtl.getByText(table, EmailAddress))
   })
 
   it('orders accounts by date registered', async () => {
@@ -125,9 +126,9 @@ describe('RegisteredAccounts page', () => {
 
     // Check that first page is correct
     _(MOCK_ACCOUNTS)
-      .orderBy('dateRegistered')
+      .orderBy('DateRegistered')
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
+      .forEach(({ EmailAddress }) => rtl.getByText(table, EmailAddress))
   })
 
   it('filters accounts by email address', async () => {
@@ -142,9 +143,9 @@ describe('RegisteredAccounts page', () => {
 
     rtl.fireEvent.change(filterInput, { target: { value: '11' } })
     _(MOCK_ACCOUNTS)
-      .filter(({ emailAddress }) => emailAddress.includes('11'))
+      .filter(({ EmailAddress }) => EmailAddress.includes('11'))
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
+      .forEach(({ EmailAddress }) => rtl.getByText(table, EmailAddress))
 
     rtl.fireEvent.change(filterInput, { target: { value: '111' } })
     rtl.getByText(table, '111@example.com')
@@ -171,9 +172,9 @@ describe('RegisteredAccounts page', () => {
 
     rtl.fireEvent.change(filterInput, { target: { value: '15' } })
     _(MOCK_ACCOUNTS)
-      .filter(({ apiKeyId }) => apiKeyId.includes('15'))
+      .filter(({ ApiKeyId }) => ApiKeyId.includes('15'))
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ apiKeyId }) => rtl.getByText(table, apiKeyId))
+      .forEach(({ ApiKeyId }) => rtl.getByText(table, ApiKeyId))
 
     rtl.fireEvent.change(filterInput, { target: { value: '155' } })
     rtl.getByText(table, 'apiKeyId155')
@@ -197,25 +198,25 @@ describe('RegisteredAccounts page', () => {
     rtl.fireEvent.change(filterInput, { target: { value: '13' } })
     rtl.fireEvent.click(dateRegisteredHeader)
     _(MOCK_ACCOUNTS)
-      .filter(({ emailAddress }) => emailAddress.includes('13'))
-      .orderBy('dateRegistered')
+      .filter(({ EmailAddress }) => EmailAddress.includes('13'))
+      .orderBy('DateRegistered')
       .take(AccountsTable.DEFAULT_PAGE_SIZE)
-      .forEach(({ emailAddress }) => rtl.getByText(table, emailAddress))
+      .forEach(({ EmailAddress }) => rtl.getByText(table, EmailAddress))
   })
 
   it('deletes an account', async () => {
     const targetAccountEmail = '1@example.com'
-    const targetAccountIdentityPoolId = 'identityPoolId1'
+    const targetAccountIdentityId = 'identityId1'
 
     AccountService.fetchRegisteredAccounts = jest
       .fn()
       .mockResolvedValueOnce(MOCK_ACCOUNTS)
       .mockResolvedValueOnce(
         MOCK_ACCOUNTS.filter(
-          account => account.emailAddress !== targetAccountEmail,
+          account => account.EmailAddress !== targetAccountEmail,
         ),
       )
-    AccountService.deleteAccountByIdentityPoolId = jest
+    AccountService.deleteAccountByIdentityId = jest
       .fn()
       .mockResolvedValueOnce(undefined)
 
@@ -237,12 +238,10 @@ describe('RegisteredAccounts page', () => {
 
     await accountsTestUtils.waitForAccountsToLoad(page)
     expect(rtl.queryByText(document, 'Confirm deletion')).toBeNull()
-    expect(
-      AccountService.deleteAccountByIdentityPoolId.mock.calls,
-    ).toHaveLength(1)
-    expect(
-      AccountService.deleteAccountByIdentityPoolId.mock.calls[0][0],
-    ).toEqual(targetAccountIdentityPoolId)
+    expect(AccountService.deleteAccountByIdentityId.mock.calls).toHaveLength(1)
+    expect(AccountService.deleteAccountByIdentityId.mock.calls[0][0]).toEqual(
+      targetAccountIdentityId,
+    )
 
     await rtl.wait(() =>
       expect(page.getByText(/Deleted account/)).toBeInTheDocument(),
@@ -257,7 +256,7 @@ describe('RegisteredAccounts page', () => {
     AccountService.fetchRegisteredAccounts = jest
       .fn()
       .mockResolvedValueOnce(MOCK_ACCOUNTS)
-    AccountService.deleteAccountByIdentityPoolId = jest
+    AccountService.deleteAccountByIdentityId = jest
       .fn()
       .mockImplementation(() => Promise.reject(new Error(errorMessage)))
 
@@ -283,12 +282,12 @@ describe('RegisteredAccounts page', () => {
 
   it('promotes an account', async () => {
     const targetAccountEmail = '2@example.com'
-    const targetAccountIdentityPoolId = 'identityPoolId2'
+    const targetAccountIdentityId = 'identityId2'
 
     AccountService.fetchRegisteredAccounts = jest
       .fn()
       .mockResolvedValueOnce(MOCK_ACCOUNTS)
-    AccountService.promoteAccountByIdentityPoolId = jest
+    AccountService.promoteAccountByIdentityId = jest
       .fn()
       .mockResolvedValueOnce(undefined)
 
@@ -310,12 +309,10 @@ describe('RegisteredAccounts page', () => {
 
     await accountsTestUtils.waitForAccountsToLoad(page)
     expect(rtl.queryByText(document, 'Confirm promotion')).toBeNull()
-    expect(
-      AccountService.promoteAccountByIdentityPoolId.mock.calls,
-    ).toHaveLength(1)
-    expect(
-      AccountService.promoteAccountByIdentityPoolId.mock.calls[0][0],
-    ).toEqual(targetAccountIdentityPoolId)
+    expect(AccountService.promoteAccountByIdentityId.mock.calls).toHaveLength(1)
+    expect(AccountService.promoteAccountByIdentityId.mock.calls[0][0]).toEqual(
+      targetAccountIdentityId,
+    )
 
     await rtl.wait(() =>
       expect(page.getByText(/Promoted account/)).toBeInTheDocument(),
@@ -330,7 +327,7 @@ describe('RegisteredAccounts page', () => {
     AccountService.fetchRegisteredAccounts = jest
       .fn()
       .mockResolvedValueOnce(MOCK_ACCOUNTS)
-    AccountService.deleteAccountByIdentityPoolId = jest
+    AccountService.deleteAccountByIdentityId = jest
       .fn()
       .mockImplementation(() => Promise.reject(new Error(errorMessage)))
 
@@ -365,11 +362,10 @@ const MOCK_DATES_REGISTERED = (() => {
 })()
 
 const MOCK_ACCOUNTS = _.range(NUM_MOCK_ACCOUNTS).map(index => ({
-  identityPoolId: `identityPoolId${index}`,
-  userPoolId: `userPoolId${index}`,
-  emailAddress: `${index}@example.com`,
-  dateRegistered: MOCK_DATES_REGISTERED[index].toJSON(),
-  apiKeyId: `apiKeyId${index}`,
-  registrationMethod: _.sample(['open', 'invite', 'request']),
-  isAdmin: index % 20 === 0,
+  IdentityId: `identityId${index}`,
+  UserId: `userId${index}`,
+  EmailAddress: `${index}@example.com`,
+  DateRegistered: MOCK_DATES_REGISTERED[index].toJSON(),
+  ApiKeyId: `apiKeyId${index}`,
+  RegistrationMethod: _.sample(['open', 'invite', 'request']),
 }))

--- a/dev-portal/src/services/accounts.js
+++ b/dev-portal/src/services/accounts.js
@@ -42,13 +42,13 @@ const mockData = (() => {
 })()
 
 const mockPendingRequestAccounts = _.cloneDeep(mockData).map(
-  ({ dateRegistered, ...rest }) => ({ ...rest, dateRequested: dateRegistered }),
+  ({ DateRegistered, ...rest }) => ({ ...rest, DateRequested: DateRegistered }),
 )
 
 const mockPendingInviteAccounts = _.cloneDeep(mockData).map(
-  ({ dateRegistered, ...rest }) => ({
+  ({ DateRegistered, ...rest }) => ({
     ...rest,
-    dateInvited: dateRegistered,
+    DateInvited: DateRegistered,
   }),
 )
 

--- a/dev-portal/src/services/accounts.js
+++ b/dev-portal/src/services/accounts.js
@@ -6,7 +6,7 @@ const NUM_MOCK_ACCOUNTS = 157 // should be prime
 const mockData = (() => {
   const now = Date.now()
   const adminStep = 10
-  return Array.from({ length: NUM_MOCK_ACCOUNTS }).map((_value, index) => {
+  return _.range(NUM_MOCK_ACCOUNTS).map(index => {
     let inviter = 1
     let promoter = null
     if (_.inRange(index, 20, 90)) {
@@ -21,21 +21,21 @@ const mockData = (() => {
     }
 
     return {
-      identityPoolId: `identityPoolId${index}`,
-      userPoolId: `userPoolId${index}`,
-      emailAddress: `${index}@example.com`,
-      datePromoted:
+      IdentityId: `identityId${index}`,
+      UserId: `userId${index}`,
+      EmailAddress: `${index}@example.com`,
+      DatePromoted:
         promoter &&
         new Date(now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000).toJSON(),
-      promoterEmailAddress: promoter && `${promoter}@example.com`,
-      promoterIdentityPoolId: promoter && `identityPoolId${promoter}`,
-      inviterEmailAddress: inviter && `${inviter}@example.com`,
-      inviterIdentityPoolId: inviter && `identityPoolId${inviter}`,
-      dateRegistered: new Date(
+      PromoterEmailAddress: promoter && `${promoter}@example.com`,
+      PromoterIdentityId: promoter && `identityId${promoter}`,
+      InviterEmailAddress: inviter && `${inviter}@example.com`,
+      InviterIdentityId: inviter && `identityId${inviter}`,
+      DateRegistered: new Date(
         now + ((index * 3) % NUM_MOCK_ACCOUNTS) * 1000,
       ).toJSON(),
-      apiKeyId: `apiKeyId${index}`,
-      registrationMethod: _.sample(['open', 'invite', 'request']),
+      ApiKeyId: `apiKeyId${index}`,
+      RegistrationMethod: _.sample(['open', 'invite', 'request']),
       isAdmin: index % adminStep === 0,
     }
   })
@@ -68,31 +68,31 @@ export const fetchPendingInviteAccounts = () => {
   return resolveAfter(1500, mockPendingInviteAccounts.slice())
 }
 
-export const deleteAccountByIdentityPoolId = async identityPoolId => {
+export const deleteAccountByIdentityId = async identityId => {
   await resolveAfter(1500)
 
   const accountIndex = mockData.findIndex(
-    account => account.identityPoolId === identityPoolId,
+    account => account.IdentityId === identityId,
   )
   if (accountIndex === -1) {
     throw new Error('Account not found!')
   }
-  if (identityPoolId.endsWith('10')) {
+  if (identityId.endsWith('10')) {
     throw new Error('Something weird happened!')
   }
   mockData.splice(accountIndex, 1)
 }
 
-export const deleteInviteByIdentityPoolId = async identityPoolId => {
+export const deleteInviteByIdentityId = async identityId => {
   await resolveAfter(1500)
 
   const accountIndex = mockPendingInviteAccounts.findIndex(
-    account => account.identityPoolId === identityPoolId,
+    account => account.IdentityId === identityId,
   )
   if (accountIndex === -1) {
     throw new Error('Account not found!')
   }
-  if (identityPoolId.endsWith('10')) {
+  if (identityId.endsWith('10')) {
     throw new Error('Something weird happened!')
   }
   mockPendingInviteAccounts.splice(accountIndex, 1)
@@ -102,24 +102,24 @@ export const createInviteByEmail = async emailAddress => {
   await resolveAfter(1500)
 
   const account = {
-      identityPoolId: `temp`,
-      userPoolId: `temp`,
-      emailAddress,
-      dateInvited: new Date(Date.now()).toJSON(),
-      inviterEmailAddress: `you@localhost`,
-      inviterIdentityPoolId: `yourIdentityId`,
-      apiKeyId: `temp`,
-      registrationMethod: `invite`,
+      IdentityId: `temp`,
+      UserId: `temp`,
+      EmailAddress: emailAddress,
+      DateInvited: new Date(Date.now()).toJSON(),
+      InviterEmailAddress: `you@localhost`,
+      InviterIdentityId: `yourIdentityId`,
+      ApiKeyId: `temp`,
+      RegistrationMethod: `invite`,
   }
 
   mockPendingInviteAccounts.push(account)
 }
 
-export const promoteAccountByIdentityPoolId = async identityPoolId => {
+export const promoteAccountByIdentityId = async identityId => {
   await resolveAfter(1500)
 
   const account = mockData.find(
-    account => account.identityPoolId === identityPoolId,
+    account => account.IdentityId === identityId,
   )
   if (account === undefined) {
     throw new Error('Account not found!')
@@ -130,31 +130,31 @@ export const promoteAccountByIdentityPoolId = async identityPoolId => {
   account.isAdmin = true
 }
 
-export const approveAccountRequestByIdentityPoolId = async identityPoolId => {
+export const approveAccountRequestByIdentityId = async identityId => {
   await resolveAfter(1500)
 
-  if (!mockPendingRequestAccounts.some(matchingIdentityId(identityPoolId))) {
+  if (!mockPendingRequestAccounts.some(matchingIdentityId(identityId))) {
     throw new Error('Account not found!')
   }
-  if (identityPoolId.endsWith('10')) {
+  if (identityId.endsWith('10')) {
     throw new Error('Something weird happened!')
   }
 
-  _.remove(mockPendingRequestAccounts, matchingIdentityId(identityPoolId))
+  _.remove(mockPendingRequestAccounts, matchingIdentityId(identityId))
 }
 
-export const denyAccountRequestByIdentityPoolId = async identityPoolId => {
+export const denyAccountRequestByIdentityId = async identityId => {
   await resolveAfter(1500)
 
-  if (!mockPendingRequestAccounts.some(matchingIdentityId(identityPoolId))) {
+  if (!mockPendingRequestAccounts.some(matchingIdentityId(identityId))) {
     throw new Error('Account not found!')
   }
-  if (identityPoolId.endsWith('10')) {
+  if (identityId.endsWith('10')) {
     throw new Error('Something weird happened!')
   }
 
-  _.remove(mockPendingRequestAccounts, matchingIdentityId(identityPoolId))
+  _.remove(mockPendingRequestAccounts, matchingIdentityId(identityId))
 }
 
 const matchingIdentityId = targetId => account =>
-  account.identityPoolId === targetId
+  account.IdentityId === targetId


### PR DESCRIPTION
*Description of changes:*
During front-end development of account management features, we use camelCase for account field names, but in fact we will serve data PascalCased from the backend. Also, we will use `IdentityId` and `UserId` field names, instead of the ambiguous `IdentityPoolId` and `UserPoolId` names. This PR applies these changes to the frontend code, in preparation for integrating with the backend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
