### PR TITLE
upgrade lambda runtime to node 12

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -994,7 +994,7 @@ Resources:
       Handler: index.handler
       MemorySize: 1024
       Role: !GetAtt BackendLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
       Environment:
         Variables:
@@ -1028,7 +1028,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt BackendLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 30
 
   CognitoUserPoolsConfirmationStrategyFunction:
@@ -1038,7 +1038,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CognitoStrategyLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 3
 
   CognitoUserPool:
@@ -1104,7 +1104,7 @@ Resources:
   CognitoUserPoolClientSettingsBackingFn:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: 128
       Timeout: 300
       CodeUri: ../lambdas/cfn-cognito-user-pools-client-settings
@@ -1184,7 +1184,7 @@ Resources:
   CognitoUserPoolDomainBackingFn:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: 128
       Timeout: 300
       CodeUri: ../lambdas/cfn-cognito-user-pools-domain
@@ -1317,7 +1317,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CatalogUpdaterLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 20
       Environment:
         Variables:
@@ -1339,7 +1339,7 @@ Resources:
       Handler: index.handler
       MemorySize: 512
       Role: !GetAtt AssetUploaderLambdaExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*
#319 
*Description of changes:*
👷 This is a maintenance PR.
🚫 The Lambda `nodejs8.10` runtime is being deprecated. 
⬆️ Updating the Node.js runtime to `nodejs12.x`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
