### PR TITLE
Switch from provisioned Dynamo to Pay Per Request

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -72,7 +72,7 @@ Parameters:
 
   StaticAssetRebuildMode:
     Type: String
-    Description: By default, a static asset rebuild doesn't overwrite custom-content. Provide the value `overwrite-content` to replace the custom-content with your local version. Don't do this unless you know what you're doing -- all custom changes in your s3 bucket will be lost. 
+    Description: By default, a static asset rebuild doesn't overwrite custom-content. Provide the value `overwrite-content` to replace the custom-content with your local version. Don't do this unless you know what you're doing -- all custom changes in your s3 bucket will be lost.
     Default: ''
     AllowedValues:
       - 'overwrite-content'
@@ -112,7 +112,7 @@ Parameters:
     Type: String
     Description: Only applicable if creating a custom domain name for your dev portal. Defaults to false, and you'll need to provide your own nameserver hosting. If set to true, a Route53 HostedZone and RecordSet are created for you.
     Default: 'false'
-    AllowedValues: 
+    AllowedValues:
       - 'false'
       - 'true'
     ConstraintDescription: Malformed input - Parameter UseRoute53Nameservers value must be either 'true' or 'false'
@@ -121,7 +121,7 @@ Parameters:
     Type: String
     Description: Enabling this weakens security features (OAI, SSL, site S3 bucket with public read ACLs, Cognito callback verification, CORS, etc.) for easier development. It also breaks frontend routing (except to /index.html), including deep linking and page refresh. Do not enable this in production! Additionally, do not update a stack that was previously in development mode to be a production stack; instead, make a new stack that has never been in development mode.
     Default: 'false'
-    AllowedValues: 
+    AllowedValues:
       - 'false'
       - 'true'
     ConstraintDescription: Malformed input - Parameter DevelopmentMode value must be either 'true' or 'false'
@@ -593,6 +593,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref DevPortalCustomersTableName
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
       - AttributeName: Id
         AttributeType: S
@@ -601,9 +602,6 @@ Resources:
       KeySchema:
       - AttributeName: Id
         KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
       GlobalSecondaryIndexes:
       - IndexName: MarketplaceCustomerIdIndex
         KeySchema:
@@ -613,24 +611,19 @@ Resources:
           NonKeyAttributes:
           - ApiKeyId
           ProjectionType: INCLUDE
-        ProvisionedThroughput:
-          ReadCapacityUnits: 5
-          WriteCapacityUnits: 5
 
   FeedbackTable:
     Type: AWS::DynamoDB::Table
     Condition: EnableFeedbackSubmission
     Properties:
       TableName: !Ref DevPortalFeedbackTableName
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
       - AttributeName: Id
         AttributeType: S
       KeySchema:
       - AttributeName: Id
         KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: '5'
-        WriteCapacityUnits: '5'
       GlobalSecondaryIndexes:
       - IndexName: FeedbackIdIndex
         KeySchema:
@@ -638,9 +631,6 @@ Resources:
           KeyType: HASH
         Projection:
           ProjectionType: KEYS_ONLY
-        ProvisionedThroughput:
-          ReadCapacityUnits: '5'
-          WriteCapacityUnits: '5'
 
   FeedbackSubmittedSNSTopic:
     Type: AWS::SNS::Topic
@@ -805,7 +795,7 @@ Resources:
           - Effect: Allow
             Action:
             - s3:ListBucket
-            Resource: 
+            Resource:
               - !Join
                 - ''
                 - - 'arn:aws:s3:::'
@@ -1082,9 +1072,9 @@ Resources:
               Service: lambda.amazonaws.com
       Policies:
         - PolicyName: WriteCloudWatchLogs
-          PolicyDocument: 
+          PolicyDocument:
             Version: '2012-10-17'
-            Statement: 
+            Statement:
               -
                 Effect: Allow
                 Action:
@@ -1093,9 +1083,9 @@ Resources:
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
         - PolicyName: UpdateUserPoolClient
-          PolicyDocument: 
+          PolicyDocument:
             Version: '2012-10-17'
-            Statement: 
+            Statement:
               -
                 Effect: Allow
                 Action: 'cognito-idp:UpdateUserPoolClient'
@@ -1154,9 +1144,9 @@ Resources:
               Service: lambda.amazonaws.com
       Policies:
         - PolicyName: WriteCloudWatchLogs
-          PolicyDocument: 
+          PolicyDocument:
             Version: '2012-10-17'
-            Statement: 
+            Statement:
               -
                 Effect: Allow
                 Action:
@@ -1165,9 +1155,9 @@ Resources:
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
         - PolicyName: ManageUserPoolDomain
-          PolicyDocument: 
+          PolicyDocument:
             Version: '2012-10-17'
-            Statement: 
+            Statement:
               -
                 Effect: Allow
                 Action: 'cognito-idp:CreateUserPoolDomain'
@@ -1198,7 +1188,7 @@ Resources:
       ServiceToken: !GetAtt CognitoUserPoolDomainBackingFn.Arn
       UserPoolId: !Ref CognitoUserPool
       Domain: !Ref CognitoDomainNameOrPrefix
-  
+
   CognitoIdentityPool:
     Type: AWS::Cognito::IdentityPool
     Properties:


### PR DESCRIPTION
API Portals are likely to be lightly utilised, switching to pay per request will reduce cost for users with light usage of the API Portal, and for users with higher usage will provide better scaling up to meet demand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
