### PR TITLE
Increase limit to allow for larger API imports/etc.

### DIFF
--- a/lambdas/backend/index.js
+++ b/lambdas/backend/index.js
@@ -12,8 +12,8 @@ const awsServerlessExpress = require('aws-serverless-express')
 const app = express()
 
 app.use(cors())
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(bodyParser.json({ limit: '10mb' }))
+app.use(bodyParser.urlencoded({ limit: '10mb', extended: true }))
 app.use(awsServerlessExpressMiddleware.eventContext())
 
 // user APIs


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Increase limit from the default [100kb](https://github.com/expressjs/body-parser/blob/master/lib/types/json.js#L54) to 10mb

This should be enough to accommodate nearly anything, and I'm pretty sure we'd hit Lambda's own limits before we hit this new limit.

Note: blocked on #350 as it's based on it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
