### PR TITLE
Fix static binary asset mangling

### DIFF
--- a/lambdas/static-asset-uploader/index.js
+++ b/lambdas/static-asset-uploader/index.js
@@ -193,7 +193,7 @@ class State {
 
     try {
       const readResults = await new Promise((resolve, reject) => {
-        fs.readFile(filePath, 'utf-8', (err, data) => {
+        fs.readFile(filePath, (err, data) => {
           if (err) reject(err)
           else resolve(data)
         })


### PR DESCRIPTION
Get rid of the file encoding when reading an asset so that node returns
the raw file data.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
