### PR TITLE
Use Chalk for terminal coloring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,34 @@
         "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/parser": {
@@ -1642,14 +1670,40 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
       }
     },
     "chardet": {
@@ -2147,6 +2201,17 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "eslint-utils": {
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
@@ -2165,11 +2230,26 @@
             "type-fest": "^0.8.1"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "regexpp": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
           "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -2963,9 +3043,9 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "has-symbols": {
@@ -6670,12 +6750,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "supports-hyperlinks": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/parser": "^2.28.0",
     "aws-sdk": "^2.656.0",
     "babel-eslint": "^10.1.0",
+    "chalk": "^4.0.0",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.20.2",

--- a/scripts/internal/execute-tasks.js
+++ b/scripts/internal/execute-tasks.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { blue, red, green } = require('./util')
+const { red, blue, green } = require('chalk')
 
 module.exports = async tasks => {
   const opts = Object.create(null)
@@ -17,10 +17,10 @@ module.exports = async tasks => {
       })
       promise.then(
         () => {
-          console.error(green('Task succeeded: ') + blue(name))
+          console.error(green('Task completed: ') + blue(name))
         },
         err => {
-          console.error(red(`Task failed: ${name}`))
+          console.error(red(`Task errored: ${name}`))
           console.error(red(err.message))
           process.exitCode = 1
         }
@@ -48,9 +48,10 @@ module.exports = async tasks => {
     const names = args.filter(arg => !arg.startsWith('--') && arg[0] !== '_')
 
     for (const arg of args) {
-      if (arg.startsWith('--')) {
+      // Ignore color-related flags in options
+      if (/^--(?!color|no-color)/.test(arg)) {
         const [key, value] = arg.slice(2).split('=')
-        opts[key] = value
+        if (value != null) opts[key] = value
       }
     }
 

--- a/scripts/internal/util.js
+++ b/scripts/internal/util.js
@@ -6,13 +6,9 @@
 const path = require('path')
 const cp = require('child_process')
 const { inspect, promisify } = require('util')
+const { red, blue, green } = require('chalk')
 
 const root = path.resolve(__dirname, '../..')
-
-const red = (text) => { return '\x1b[31m' + text + '\x1b[0m' }
-const blue = (text) => { return '\x1b[34m' + text + '\x1b[0m' }
-const green = (text) => { return '\x1b[32m' + text + '\x1b[0m' }
-const yellow = (text) => { return '\x1b[33m' + text + '\x1b[0m' }
 
 async function execPipe (name, args = []) {
   console.error(blue('[ run cmd ]  ' + [name, ...args].join(' ')))
@@ -70,10 +66,6 @@ const packageList = [
 }))
 
 module.exports = {
-  red,
-  blue,
-  green,
-  yellow,
   execPipe,
   exec,
   run,

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -3,7 +3,8 @@
 // Note: this *MUST NOT* globally depend on any module installed in `node_modules`, as it could be
 // loaded before they're installed.
 
-const { p, run, exec, green, blue, packageList } = require('./internal/util.js')
+const { p, run, exec, packageList } = require('./internal/util.js')
+const { blue, green, supportsColor } = require('chalk')
 const deployTemplate = require('./internal/deploy-template.js')
 const writeConfig = require('./internal/write-config.js')
 
@@ -53,7 +54,11 @@ require('./internal/execute-tasks.js')({
   },
 
   async test (opts) {
-    await exec('node', [p('scripts/test'), ...Object.entries(opts).map(p => '--' + p.join('='))])
+    await exec('node', [p('scripts/test'), ...Object.entries(opts).map(p => '--' + p.join('='))], {
+      // Output with color, even through pipes.
+      // Do proxy existing color support, though.
+      env: { ...process.env, FORCE_COLOR: supportsColor ? supportsColor.level : '1' }
+    })
   },
 
   async build () {


### PR DESCRIPTION
It properly handles color enabling/disabling, among other things.

Also, don't rely on the current working directory in `test.js` - it was
causing errors running it from the root.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
