### PR TITLE
remove `undefined` from the endpoint if basepath isn't defined (gener…

### DIFF
--- a/dev-portal/src/components/SwaggerUiLayout.jsx
+++ b/dev-portal/src/components/SwaggerUiLayout.jsx
@@ -30,7 +30,7 @@ export const SwaggerLayoutPlugin = () => ({ components: { InfoContainer: InfoRep
 function InfoReplacement ({ specSelectors }) {
   let endpoint
   if (specSelectors.hasHost()) {
-    endpoint = `https://${specSelectors.host()}${specSelectors.basePath()}`
+    endpoint = `https://${specSelectors.host()}${specSelectors.basePath() || ''}`
   } else {
     const servers = specSelectors.servers()
     if (servers && servers.size) endpoint = servers.getIn([0, 'url'])


### PR DESCRIPTION
*Description of changes:*

Just prevents `undefined` from being added to the URL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
