### PR TITLE
Revert a breaking change to user pools, retain them post-deletion

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1272,6 +1272,8 @@ Resources:
 
   CognitoUserPool:
     Type: AWS::Cognito::UserPool
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       UserPoolName: !Ref CognitoIdentityPoolName
       # Lambda trigger caveats:
@@ -1306,7 +1308,6 @@ Resources:
       Schema:
         - AttributeDataType: String
           Name: email
-          Required: true
       AdminCreateUserConfig:
         AllowAdminCreateUserOnly: !If [
           InviteAccountRegistrationMode, 'true', 'false',

--- a/lambdas/cognito-pre-signup-trigger/index.js
+++ b/lambdas/cognito-pre-signup-trigger/index.js
@@ -10,15 +10,27 @@
 // hosted UI will block the user from signing up, and this lambda will never
 // run.
 
+// Pulled from https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type%3Demail) and
+// optimized in a few ways for size:
+// - Classes of `[A-Za-z0-9]` were shortened to the equivalent `[^_\W]`.
+// - Other instances of `0-9` in classes were converted to the shorthand `\d`.
+// - The whole regexp was made case-insensitive to avoid the need for `A-Za-z` in classes.
+// - As we're only testing, I replaced all the non-capturing groups with capturing ones.
+//
+// This is the same regexp as is used in dev-portal/src/pages/Admin/Accounts/PendingInvites.jsx.
+const validEmailRegex =
+  /^[\w.!#$%&'*+\/=?^`{|}~-]+@[^_\W]([a-z\d-]{0,61}[^_\W])?(\.[^_\W]([a-z\d-]{0,61}[^_\W])?)*$/i
+
 exports.handler = async event => {
+  const email = event.request.userAttributes.email
+  if (email == null) throw new Error('Email is required.')
+  if (!validEmailRegex.test(email)) throw new Error('Email is invalid.')
+
   // To block the sign-up from occurring, throw an error. The message will be
   // displayed to the user when they attempt to sign up, before Cognito asks
   // for confirmation.
 
-  console.info(
-    `In Pre Signup Trigger for username=[${event.userName}]` +
-      ` and email=[${event.request.userAttributes.email}]`
-  )
+  console.info(`In Pre Signup Trigger for username=[${event.userName}] and email=[${email}]`)
 
   return event
 }


### PR DESCRIPTION
Instead of changing the schema, I'm enforcing it in the lambda, to avoid
Cognito's limitation of not being able to modify existing attributes
on user pools.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
