### PR TITLE
Will now accept .yml files and checks the end of the filename

### DIFF
--- a/dev-portal/src/pages/Admin/ApiManagement.jsx
+++ b/dev-portal/src/pages/Admin/ApiManagement.jsx
@@ -97,7 +97,7 @@ export const ApiManagement = observer(class ApiManagement extends React.Componen
         const reader = new window.FileReader()
 
         reader.onload = (e) => {
-          if (file.name.includes('yaml')) {
+          if (file.name.endsWith('.yaml') || file.name.endsWith('.yml')) {
             swaggerObject = YAML.parse(e.target.result)
             swagger = JSON.stringify(swaggerObject)
           } else {


### PR DESCRIPTION
*Issue #430 
Will now accept uploads of .yml files and work correctly with files named like yaml.json

*Description of changes:
Checks the end of the filename for the extension instead of anywhere in the filename (should avoid cases like a file being name yaml.json)
Accepts files ending with .yml correctly as the uploading box indicates it should.

Just a quick fix, there could probably be some better notification for the user on error too but this should at least do what the prompt says it will now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
