### PR TITLE
Support for accounts with no registration date.

### DIFF
--- a/dev-portal/src/components/Admin/Accounts/AccountsTableColumns.jsx
+++ b/dev-portal/src/components/Admin/Accounts/AccountsTableColumns.jsx
@@ -49,7 +49,7 @@ export const IsAdmin = {
 export const DateRegistered = {
   id: 'DateRegistered',
   title: 'Date registered',
-  render: account => formatDate(account.DateRegistered),
+  render: account => account.DateRegistered ? formatDate(account.DateRegistered) : '-',
   ordering: {
     iteratee: 'DateRegistered'
   }


### PR DESCRIPTION
*Issue:
As an administrator, when accessing `Admin Panel -> Users` if there are users without a `DateRegistered` field the page hangs and no error is displayed


*Description of changes:
- If a pending user has not a `DateRegistered` field a `-` is displayed instead


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
