### PR TITLE
Add new `region` key to allow deploying to alternate regions explicitly

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -57,6 +57,12 @@ This S3 bucket is used to hold all the build artifacts. Unlike everything else h
 
 This is the name of the CloudFormation stack to create and deploy. As a CloudFormation stack name, it must be unique to your account.
 
+### `region: string` (Required)
+
+This is the name of the region to deploy the CloudFormation stack to.
+
+Note: the edge lambda will always be created in us-east-1 regardless of the value of this.
+
 ### `siteAssetsBucket: string` (Required)
 
 This S3 bucket holds the site's static assets to serve from the generated CloudFront distribution. As an S3 bucket, the name must be globally unique.

--- a/dev-portal/example-deployer.config.js
+++ b/dev-portal/example-deployer.config.js
@@ -16,6 +16,9 @@
 'use strict'
 
 module.exports = {
+  // Optional
+  // region: 'us-west-1',
+
   // Optional, but recommended if you have multiple active AWS CLI profiles.
   // awsSamCliProfile: 'your-profile',
 

--- a/dev-portal/example-dev-deployer.config.js
+++ b/dev-portal/example-dev-deployer.config.js
@@ -9,6 +9,9 @@
 const n = 0
 
 module.exports = {
+  // Optional
+  // region: 'us-west-1',
+
   buildAssetsBucket: 'YOUR_LAMBDA_ARTIFACTS_BUCKET_NAME',
 
   // All of these are parametric over `n` so that if you need to have multiple stacks deployed

--- a/scripts/internal/deploy-template.js
+++ b/scripts/internal/deploy-template.js
@@ -10,6 +10,7 @@ module.exports = async () => {
 
   const {
     stackName,
+    region,
     buildAssetsBucket,
     siteAssetsBucket,
     apiAssetsBucket,
@@ -36,6 +37,7 @@ module.exports = async () => {
 
   await exec('sam', [
     'package',
+    '--region', region,
     '--template-file', samTemplate,
     '--output-template-file', packageConfig,
     '--s3-bucket', buildAssetsBucket,
@@ -43,6 +45,7 @@ module.exports = async () => {
   ])
   await exec('sam', [
     'deploy',
+    '--region', region,
     '--template-file', packageConfig,
     '--stack-name', stackName,
     '--capabilities', 'CAPABILITY_NAMED_IAM',

--- a/scripts/internal/get-deployer-config.js
+++ b/scripts/internal/get-deployer-config.js
@@ -42,6 +42,7 @@ exports.cognitoDomainName = getRequired('cognitoDomainName')
 // required (and defaulted) inputs
 exports.samTemplate = getOptionalPath('samTemplate', 'cloudformation/template.yaml')
 exports.packageConfig = getOptionalPath('packageConfig', 'cloudformation/packaged.yaml')
+exports.region = getOptional('region', 'us-east-1')
 exports.customersTableName = getOptional('customersTableName')
 exports.preLoginAccountsTableName = getOptional('preLoginAccountsTableName')
 exports.feedbackTableName = getOptional('feedbackTableName')


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-api-gateway-developer-portal/issues/488#issuecomment-914292194 (possibly)

*Description of changes:* Title's pretty obvious, as is the patch. Won't require a new release as it only touches dev scripts.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
