### PR TITLE
Correct X-XSS-Protection header value in dev portal

### DIFF
--- a/lambdas/cloudfront-security/index.js
+++ b/lambdas/cloudfront-security/index.js
@@ -17,7 +17,7 @@ const headersToAdd = {
   }],
   'x-content-type-options': [{ value: 'nosniff' }],
   'x-frame-options': [{ value: 'DENY' }],
-  'x-xss-protection': [{ value: '1; mode=block' }],
+  'x-xss-protection': [{ value: '0' }],
   'referrer-policy': [{ value: 'same-origin' }]
 }
 


### PR DESCRIPTION
Updating the value to `0`, as described here: https://stackoverflow.com/questions/9090577/what-is-the-http-header-x-xss-protection/57802070#57802070
