### PR TITLE
Pick up latest security fix in forked swagger-ui branch

### DIFF
--- a/dev-portal/node_modules/swagger-ui/package.json
+++ b/dev-portal/node_modules/swagger-ui/package.json
@@ -1,12 +1,6 @@
 {
-  "_args": [
-    [
-      "swagger-ui@git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
-      "/Volumes/workplace/aws-api-gateway-developer-portal/dev-portal"
-    ]
-  ],
-  "_from": "swagger-ui@git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
-  "_id": "swagger-ui@git+ssh://git@github.com/awslabs/swagger-ui.git#77b2f810dbc845bab8b94da2032866ac39d7ff8a",
+  "_from": "github:awslabs/swagger-ui#apigw-fork-v4",
+  "_id": "swagger-ui@3.22.3",
   "_inBundle": false,
   "_integrity": "",
   "_location": "/swagger-ui",
@@ -15,20 +9,19 @@
   },
   "_requested": {
     "type": "git",
-    "raw": "swagger-ui@git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
-    "name": "swagger-ui",
-    "escapedName": "swagger-ui",
-    "rawSpec": "git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
-    "saveSpec": "git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
-    "fetchSpec": "https://github.com/awslabs/swagger-ui.git",
+    "raw": "awslabs/swagger-ui#apigw-fork-v4",
+    "rawSpec": "awslabs/swagger-ui#apigw-fork-v4",
+    "saveSpec": "github:awslabs/swagger-ui#apigw-fork-v4",
+    "fetchSpec": null,
     "gitCommittish": "apigw-fork-v4"
   },
   "_requiredBy": [
+    "#USER",
     "/"
   ],
-  "_resolved": "git+ssh://git@github.com/awslabs/swagger-ui.git#77b2f810dbc845bab8b94da2032866ac39d7ff8a",
-  "_spec": "git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
-  "_where": "/Volumes/workplace/aws-api-gateway-developer-portal/dev-portal",
+  "_resolved": "github:awslabs/swagger-ui#7ded8cb170111ff0809339dfd896a53396863539",
+  "_spec": "awslabs/swagger-ui#apigw-fork-v4",
+  "_where": "/Volumes/workplace/oncall/aws-api-gateway-developer-portal/dev-portal",
   "browserslist": [
     "> 1%",
     "last 2 versions",
@@ -37,6 +30,7 @@
   "bugs": {
     "url": "https://github.com/swagger-api/swagger-ui/issues"
   },
+  "bundleDependencies": false,
   "bundlesize": [
     {
       "path": "./dist/swagger-ui-bundle.js",
@@ -77,7 +71,7 @@
     }
   ],
   "dependencies": {
-    "@braintree/sanitize-url": "^2.0.2",
+    "@braintree/sanitize-url": "^6.0.0",
     "@kyleshockey/js-yaml": "^1.0.1",
     "@kyleshockey/object-assign-deep": "^0.4.2",
     "@kyleshockey/xml": "^1.0.2",
@@ -110,6 +104,7 @@
     "xml-but-prettier": "^1.0.1",
     "zenscroll": "^4.0.2"
   },
+  "deprecated": false,
   "description": "[![NPM version](https://badge.fury.io/js/swagger-ui.svg)](http://badge.fury.io/js/swagger-ui) [![Build Status](https://jenkins.swagger.io/view/OSS%20-%20JavaScript/job/oss-swagger-ui-master/badge/icon?subject=jenkins%20build)](https://jenkins.swagger.io/view/OSS%20-%20JavaScript/job/oss-swagger-ui-master/)",
   "devDependencies": {
     "autoprefixer": "^8.4.1",

--- a/dev-portal/package-lock.json
+++ b/dev-portal/package-lock.json
@@ -1386,9 +1386,9 @@
       "dev": true
     },
     "@braintree/sanitize-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-2.1.0.tgz",
-      "integrity": "sha1-VJqdH5I8m8eVOlhdPpqpQpvo/ig="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "@csstools/normalize.css": {
       "version": "12.0.0",
@@ -2418,14 +2418,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@kyleshockey/js-yaml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@kyleshockey/js-yaml/-/js-yaml-1.0.1.tgz",
-      "integrity": "sha512-coFyIk1LvTscq1cUU4nCCfYwv+cmG4fCP+wgDKgYZjhM4f++YwZy+g0k+1tUqa4GuUpBTEOGH2KUqKFFWdT73g==",
-      "requires": {
-        "argparse": "^1.0.7"
       }
     },
     "@kyleshockey/object-assign-deep": {
@@ -3544,9 +3536,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true
     },
     "ansi-styles": {
@@ -14588,10 +14580,10 @@
       }
     },
     "swagger-ui": {
-      "version": "git+ssh://git@github.com/awslabs/swagger-ui.git#77b2f810dbc845bab8b94da2032866ac39d7ff8a",
-      "from": "swagger-ui@git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
+      "version": "github:awslabs/swagger-ui#7ded8cb170111ff0809339dfd896a53396863539",
+      "from": "github:awslabs/swagger-ui#apigw-fork-v4",
       "requires": {
-        "@braintree/sanitize-url": "^2.0.2",
+        "@braintree/sanitize-url": "^6.0.0",
         "@kyleshockey/js-yaml": "^1.0.1",
         "@kyleshockey/object-assign-deep": "^0.4.2",
         "@kyleshockey/xml": "^1.0.2",
@@ -14623,6 +14615,16 @@
         "url-parse": "^1.4.3",
         "xml-but-prettier": "^1.0.1",
         "zenscroll": "^4.0.2"
+      },
+      "dependencies": {
+        "@kyleshockey/js-yaml": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@kyleshockey/js-yaml/-/js-yaml-1.0.1.tgz",
+          "integrity": "sha512-coFyIk1LvTscq1cUU4nCCfYwv+cmG4fCP+wgDKgYZjhM4f++YwZy+g0k+1tUqa4GuUpBTEOGH2KUqKFFWdT73g==",
+          "requires": {
+            "argparse": "^1.0.7"
+          }
+        }
       }
     },
     "symbol-observable": {

--- a/dev-portal/package.json
+++ b/dev-portal/package.json
@@ -18,7 +18,7 @@
     "react-router-dom": "^4.3.1",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.87.3",
-    "swagger-ui": "git+https://github.com/awslabs/swagger-ui.git#apigw-fork-v4",
+    "swagger-ui": "github:awslabs/swagger-ui#apigw-fork-v4",
     "yamljs": "^0.3.0"
   },
   "scripts": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix security issues related to `sanitize-url`.  The dependency is fixed in `swagger-ui`, and now we are just picking it up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
