### PR TITLE
Add shell to spawn to support Windows

### DIFF
--- a/scripts/internal/util.js
+++ b/scripts/internal/util.js
@@ -18,7 +18,7 @@ async function execPipe (name, args = []) {
 
 const exec = (name, args = [], opts = {}) => new Promise(resolve => {
   console.error(blue('[ run cmd ]  ' + [name, ...args].join(' ')))
-  cp.spawn(name, args, { stdio: 'inherit', cwd: root, ...opts })
+  cp.spawn(name, args, { stdio: 'inherit', cwd: root, shell: true, ...opts })
     .on('exit', (status, signal) => resolve({ status, signal }))
     .on('error', error => resolve({ error }))
 })


### PR DESCRIPTION
*Description of changes:*
This fixes an issue where child processes are not being correctly spawned on Windows. 

Documentation can be found here:
https://nodejs.org/dist/latest-v16.x/docs/api/child_process.html#spawning-bat-and-cmd-files-on-windows
