### PR TITLE
Upgrade the Nodejs 16.x Runtime version to Nodejs 18.x

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1227,7 +1227,7 @@ Resources:
       Description: 'Common code used by lambdas'
       ContentUri: ../lambdas/common-layer/
       CompatibleRuntimes:
-        - nodejs16.x
+        - nodejs18.x
 
   DevPortalLambdaFunction:
     Type: AWS::Serverless::Function
@@ -1236,7 +1236,7 @@ Resources:
       Handler: index.handler
       MemorySize: 1024
       Role: !GetAtt BackendLambdaExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 30
       Environment:
         Variables:
@@ -1279,7 +1279,7 @@ Resources:
   #     Handler: index.handler
   #     MemorySize: 128
   #     Role: !GetAtt BackendLambdaExecutionRole.Arn
-  #     Runtime: nodejs16.x
+  #     Runtime: nodejs18.x
   #     Timeout: 30
   #     Layers:
   #       - !Ref LambdaCommonLayer
@@ -1292,7 +1292,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CognitoPreSignupTriggerExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 3
       Environment:
         Variables:
@@ -1308,7 +1308,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CognitoPostConfirmationTriggerExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 3
       Environment:
         Variables:
@@ -1326,7 +1326,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CognitoPostAuthenticationTriggerExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 3
       Environment:
         Variables:
@@ -1455,7 +1455,7 @@ Resources:
   CognitoUserPoolClientSettingsBackingFn:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 300
       CodeUri: ../lambdas/cfn-cognito-user-pools-client-settings
@@ -1539,7 +1539,7 @@ Resources:
   CognitoUserPoolDomainBackingFn:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 300
       CodeUri: ../lambdas/cfn-cognito-user-pools-domain
@@ -1710,7 +1710,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt CatalogUpdaterLambdaExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 20
       Environment:
         Variables:
@@ -1735,7 +1735,7 @@ Resources:
       Handler: index.handler
       MemorySize: 512
       Role: !GetAtt AssetUploaderLambdaExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 300
       Environment:
         Variables:
@@ -1789,7 +1789,7 @@ Resources:
       Handler: replicator.handler
       MemorySize: 128
       Role: !GetAtt CloudFrontEdgeReplicatorRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 300
       AutoPublishAlias: Live
       Environment:
@@ -1958,7 +1958,7 @@ Resources:
       Handler: index.handler
       MemorySize: 512
       Role: !GetAtt DumpV3AccountDataExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 300
       Environment:
         Variables:
@@ -2068,7 +2068,7 @@ Resources:
       Handler: index.handler
       MemorySize: 512
       Role: !GetAtt UserGroupImporterExecutionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       # Use the default max timeout duration.
       Timeout: 900
       Environment:


### PR DESCRIPTION
Here are the issues that have been registered in the main repo so far.
[https://github.com/https://github.com/awslabs/aws-api-gateway-developer-portal/issues/620]
[https://github.com/https://github.com/awslabs/aws-api-gateway-developer-portal/issues/619]
[https://github.com/https://github.com/awslabs/aws-api-gateway-developer-portal/issues/580]

Upgraded the Nodejs Runtime version to 18.x in Cloudformation Template.